### PR TITLE
feat(cli): run diff through engine

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -20,6 +20,7 @@ pub mod diff_parser;
 
 use crate::config::Config;
 use crate::error::Result;
+use crate::report::ReviewReport;
 
 /// The main engine struct.
 pub struct ReviewEngine {
@@ -32,15 +33,18 @@ impl ReviewEngine {
         Self { config }
     }
 
-    /// Runs a complete code review analysis on a given diff.
-    pub async fn run(&self, diff: &str) -> Result<()> {
+    /// Runs a complete code review analysis on a given diff and
+    /// returns a structured report of the findings.
+    pub async fn run(&self, diff: &str) -> Result<ReviewReport> {
         println!("Engine running with config: {:?}", self.config);
         println!("Analyzing diff: {}", diff);
-        // 1. Parse the diff.
-        // 2. Use scanner to find hard-coded issues.
-        // 3. Use RAG to fetch relevant context from the codebase.
-        // 4. Use LLM to generate insights and suggestions.
-        // 5. Generate a report.
-        todo!("Implement the main review logic");
+
+        // TODO: Implement the real review logic.
+        // For now, return an empty report so downstream consumers
+        // can exercise their logic without panicking.
+        Ok(ReviewReport {
+            summary: "Analysis not implemented".to_string(),
+            issues: Vec::new(),
+        })
     }
 }


### PR DESCRIPTION
## Summary
- generate git diff for the `check` subcommand
- execute the engine on the diff and write a markdown report
- return a structured report from the engine

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c55c25e9c8832db60bb622574acbbb