### PR TITLE
Use structured logging with verbosity control

### DIFF
--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -2,6 +2,7 @@
 
 use clap::Args;
 use engine::ReviewEngine;
+use log::info;
 
 #[derive(Args, Debug)]
 pub struct CheckArgs {
@@ -20,10 +21,10 @@ pub struct CheckArgs {
 
 /// Executes the `check` subcommand.
 pub async fn run(args: CheckArgs, engine: &ReviewEngine) -> anyhow::Result<()> {
-    println!("Running 'check' with the following arguments:");
-    println!("  Diff base: {}", args.diff);
-    println!("  Path: {}", args.path);
-    println!("  Output: {}", args.output);
+    info!("Running 'check' with the following arguments:");
+    info!("  Diff base: {}", args.diff);
+    info!("  Path: {}", args.path);
+    info!("  Output: {}", args.output);
 
     // In a real implementation:
     // 1. Use git2 or a shell command to generate the diff from `args.diff`.
@@ -33,7 +34,7 @@ pub async fn run(args: CheckArgs, engine: &ReviewEngine) -> anyhow::Result<()> {
     engine.run(diff_content).await.map_err(|e| anyhow::anyhow!(e))?;
 
     // 3. Write the report from the engine's output to `args.output`.
-    println!("\nReview complete. Report would be written to {}.", args.output);
+    info!("\nReview complete. Report would be written to {}.", args.output);
 
     // 4. Exit with an appropriate status code for CI.
     // For now, we'll just exit with 0.

--- a/crates/cli/src/commands/index.rs
+++ b/crates/cli/src/commands/index.rs
@@ -2,6 +2,7 @@
 
 use clap::Args;
 use engine::ReviewEngine;
+use log::info;
 
 #[derive(Args, Debug)]
 pub struct IndexArgs {
@@ -16,15 +17,15 @@ pub struct IndexArgs {
 
 /// Executes the `index` subcommand.
 pub async fn run(args: IndexArgs, _engine: &ReviewEngine) -> anyhow::Result<()> {
-    println!("Running 'index' with the following arguments:");
-    println!("  Path: {}", args.path);
-    println!("  Force: {}", args.force);
+    info!("Running 'index' with the following arguments:");
+    info!("  Path: {}", args.path);
+    info!("  Force: {}", args.force);
 
     // In a real implementation:
     // 1. Find all relevant files in `args.path` based on the engine's config.
     // 2. Call the engine's indexing module to create or update the RAG index.
-    println!("\nIndexing would be performed here.");
-    println!("This process would scan the codebase and populate a vector store for RAG.");
+    info!("\nIndexing would be performed here.");
+    info!("This process would scan the codebase and populate a vector store for RAG.");
 
     Ok(())
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2,6 +2,7 @@
 
 use clap::Parser;
 use engine::ReviewEngine;
+use log::LevelFilter;
 
 mod commands;
 
@@ -29,10 +30,16 @@ enum Commands {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // Initialize logging
-    env_logger::init();
-
     let cli = Cli::parse();
+
+    let mut builder = env_logger::Builder::from_env(env_logger::Env::default());
+    builder.filter_level(match cli.verbose {
+        0 => LevelFilter::Warn,
+        1 => LevelFilter::Info,
+        2 => LevelFilter::Debug,
+        _ => LevelFilter::Trace,
+    });
+    builder.init();
 
     // Placeholder: Load config and initialize the engine
     // In a real app, you'd load this from a `reviewer.toml` file.

--- a/crates/engine/src/diff_parser.rs
+++ b/crates/engine/src/diff_parser.rs
@@ -1,6 +1,7 @@
 //! Logic for parsing diffs to identify changed files and hunks.
 
 use crate::error::{EngineError, Result};
+use log::info;
 
 /// Represents a single changed file in a diff.
 #[derive(Debug)]
@@ -43,7 +44,7 @@ pub fn parse(diff_text: &str) -> Result<Vec<ChangedFile>> {
         return Ok(Vec::new());
     }
 
-    println!("Parsing diff...");
+    info!("Parsing diff...");
     // Placeholder logic
     todo!("Implement diff parsing logic.");
 }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -20,6 +20,7 @@ pub mod diff_parser;
 
 use crate::config::Config;
 use crate::error::Result;
+use log::info;
 
 /// The main engine struct.
 pub struct ReviewEngine {
@@ -34,8 +35,8 @@ impl ReviewEngine {
 
     /// Runs a complete code review analysis on a given diff.
     pub async fn run(&self, diff: &str) -> Result<()> {
-        println!("Engine running with config: {:?}", self.config);
-        println!("Analyzing diff: {}", diff);
+        info!("Engine running with config: {:?}", self.config);
+        info!("Analyzing diff: {}", diff);
         // 1. Parse the diff.
         // 2. Use scanner to find hard-coded issues.
         // 3. Use RAG to fetch relevant context from the codebase.

--- a/crates/engine/src/llm/mod.rs
+++ b/crates/engine/src/llm/mod.rs
@@ -6,6 +6,7 @@
 
 use crate::error::Result;
 use async_trait::async_trait;
+use log::info;
 
 /// Represents a response from an LLM.
 pub struct LlmResponse {
@@ -34,9 +35,9 @@ pub struct LocalOnlyProvider;
 #[async_trait]
 impl LlmProvider for LocalOnlyProvider {
     async fn generate(&self, prompt: &str) -> Result<LlmResponse> {
-        println!("--- LLM Call (Local-Only Mode) ---");
-        println!("Prompt: {}", prompt);
-        println!("--- End LLM Call ---");
+        info!("--- LLM Call (Local-Only Mode) ---");
+        info!("Prompt: {}", prompt);
+        info!("--- End LLM Call ---");
 
         Ok(LlmResponse {
             content: "This is a dummy response from the local-only provider.".to_string(),

--- a/crates/engine/src/rag/mod.rs
+++ b/crates/engine/src/rag/mod.rs
@@ -5,6 +5,7 @@
 
 use crate::error::Result;
 use async_trait::async_trait;
+use log::info;
 
 /// A trait for a vector store that can store and retrieve embeddings.
 #[async_trait]
@@ -34,7 +35,7 @@ pub struct RagContextRetriever {
 
 impl RagContextRetriever {
     pub async fn retrieve(&self, query: &str) -> Result<String> {
-        println!("Retrieving RAG context for query: {}", query);
+        info!("Retrieving RAG context for query: {}", query);
         // 1. Generate embedding for the query.
         // 2. Search the vector store.
         // 3. Format and return the results as a string.


### PR DESCRIPTION
## Summary
- replace legacy `println!` calls with `log` macros for structured output
- allow the `-v/--verbose` flag to set the global log level

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c55c28b8a0832dbcb41e84dc664c12