### PR TITLE
Add repository indexing and RAG context to prompts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,9 @@ reqwest = { version = "0.11", features = ["json"] }
 thiserror = "1.0"
 anyhow = "1.0"
 
+# Filesystem walking
+walkdir = "2"
+
 # Tracing & Telemetry (for later)
 # tracing = "0.1"
 # tracing-subscriber = "0.3"

--- a/crates/cli/src/commands/index.rs
+++ b/crates/cli/src/commands/index.rs
@@ -1,6 +1,7 @@
 //! The `index` subcommand.
 
 use clap::Args;
+use engine::rag::index_repository;
 use engine::ReviewEngine;
 
 #[derive(Args, Debug)]
@@ -16,15 +17,7 @@ pub struct IndexArgs {
 
 /// Executes the `index` subcommand.
 pub async fn run(args: IndexArgs, _engine: &ReviewEngine) -> anyhow::Result<()> {
-    println!("Running 'index' with the following arguments:");
-    println!("  Path: {}", args.path);
-    println!("  Force: {}", args.force);
-
-    // In a real implementation:
-    // 1. Find all relevant files in `args.path` based on the engine's config.
-    // 2. Call the engine's indexing module to create or update the RAG index.
-    println!("\nIndexing would be performed here.");
-    println!("This process would scan the codebase and populate a vector store for RAG.");
-
+    let _store = index_repository(&args.path, args.force).await?;
+    println!("Indexing complete.");
     Ok(())
 }

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -19,6 +19,7 @@ async-trait.workspace = true
 thiserror.workspace = true
 anyhow.workspace = true
 reqwest.workspace = true
+walkdir.workspace = true
 
 # Crate-specific dependencies
 # Example: for git operations


### PR DESCRIPTION
## Summary
- implement simple repository indexer that scans files and populates an in-memory vector store
- hook up CLI `index` command to execute the indexer
- include retrieved RAG context in the prompt sent to the LLM

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c570999684832d914ba39216f26321