### PR TITLE
Filter changed files by config path globs

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -26,8 +26,12 @@ reqwest.workspace = true
 # Example: for regex-based scanning
 regex = "1.10"
 once_cell = "1"
+globset = "0.4"
 
 [features]
 default = []
 owasp_top_5 = []
 secrets = []
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -19,12 +19,14 @@ pub mod report;
 pub mod scanner;
 
 use crate::config::Config;
-use crate::error::Result;
+use crate::error::{EngineError, Result};
 use crate::llm::{create_llm_provider, LlmProvider};
 use crate::rag::{InMemoryVectorStore, RagContextRetriever};
 use crate::report::ReviewReport;
 use crate::scanner::Scanner;
+use globset::{Glob, GlobSet, GlobSetBuilder};
 use std::fs;
+use std::path::Path;
 
 /// The main engine struct.
 pub struct ReviewEngine {
@@ -38,7 +40,11 @@ impl ReviewEngine {
     pub fn new(config: Config) -> Result<Self> {
         let llm = create_llm_provider(&config)?;
         let scanners = crate::scanner::load_enabled_scanners(&config);
-        Ok(Self { config,scanners, llm })
+        Ok(Self {
+            config,
+            scanners,
+            llm,
+        })
     }
 
     /// Runs a complete code review analysis on a given diff.
@@ -49,9 +55,22 @@ impl ReviewEngine {
         // 1. Parse the diff to identify changed files and hunks.
         let changed_files = diff_parser::parse(diff)?;
 
-        // 2. Run configured scanners on the changed files.
+        // Build globsets for allowed and denied paths.
+        let allow_set = build_globset(&self.config.paths.allow)?;
+        let deny_set = build_globset(&self.config.paths.deny)?;
+
+        // Filter changed files based on glob patterns.
+        let filtered_files: Vec<_> = changed_files
+            .into_iter()
+            .filter(|file| {
+                let path = Path::new(&file.path);
+                allow_set.is_match(path) && !deny_set.is_match(path)
+            })
+            .collect();
+
+        // 2. Run configured scanners on the filtered files.
         let mut issues = Vec::new();
-        for file in changed_files {
+        for file in filtered_files {
             let content = fs::read_to_string(&file.path)?;
             for scanner in &self.scanners {
                 let mut found = scanner.scan(&file.path, &content, &self.config)?;
@@ -63,7 +82,10 @@ impl ReviewEngine {
         let rag = RagContextRetriever::new(Box::new(InMemoryVectorStore::default()));
         for issue in &issues {
             let _ = rag
-                .retrieve(&format!("{}:{} {}", issue.file_path, issue.line_number, issue.description))
+                .retrieve(&format!(
+                    "{}:{} {}",
+                    issue.file_path, issue.line_number, issue.description
+                ))
                 .await?;
         }
 
@@ -83,4 +105,15 @@ impl ReviewEngine {
 
         Ok(report)
     }
+}
+
+fn build_globset(patterns: &[String]) -> Result<GlobSet> {
+    let mut builder = GlobSetBuilder::new();
+    for pattern in patterns {
+        let glob = Glob::new(pattern).map_err(|e| EngineError::Config(e.to_string()))?;
+        builder.add(glob);
+    }
+    builder
+        .build()
+        .map_err(|e| EngineError::Config(e.to_string()))
 }

--- a/crates/engine/tests/paths.rs
+++ b/crates/engine/tests/paths.rs
@@ -1,0 +1,60 @@
+use engine::config::Config;
+use engine::ReviewEngine;
+
+fn diff_for_file(path: &str, line: &str) -> String {
+    format!(
+        "diff --git a/{0} b/{0}\n--- a/{0}\n+++ b/{0}\n@@ -0,0 +1 @@\n+{1}\n",
+        path, line
+    )
+}
+
+#[tokio::test]
+async fn respects_allow_patterns() {
+    let temp = tempfile::tempdir().unwrap();
+    let secret_line = "const API_KEY = \"sk_live_1234567890abcdef1234567890abcdef\";";
+    std::fs::write(temp.path().join("included.rs"), secret_line).unwrap();
+    std::fs::write(temp.path().join("other.rs"), secret_line).unwrap();
+
+    let diff = format!(
+        "{}{}",
+        diff_for_file("included.rs", secret_line),
+        diff_for_file("other.rs", secret_line)
+    );
+
+    let mut config = Config::default();
+    config.paths.allow = vec!["included.rs".into()];
+
+    let engine = ReviewEngine::new(config).unwrap();
+
+    std::env::set_current_dir(temp.path()).unwrap();
+    let report = engine.run(&diff).await.unwrap();
+
+    assert_eq!(report.issues.len(), 1);
+    assert_eq!(report.issues[0].file_path, "included.rs");
+}
+
+#[tokio::test]
+async fn respects_deny_patterns() {
+    let temp = tempfile::tempdir().unwrap();
+    let secret_line = "const API_KEY = \"sk_live_1234567890abcdef1234567890abcdef\";";
+    std::fs::write(temp.path().join("included.rs"), secret_line).unwrap();
+    std::fs::write(temp.path().join("excluded.rs"), secret_line).unwrap();
+
+    let diff = format!(
+        "{}{}",
+        diff_for_file("included.rs", secret_line),
+        diff_for_file("excluded.rs", secret_line)
+    );
+
+    let mut config = Config::default();
+    config.paths.allow = vec!["*.rs".into()];
+    config.paths.deny = vec!["excluded.rs".into()];
+
+    let engine = ReviewEngine::new(config).unwrap();
+
+    std::env::set_current_dir(temp.path()).unwrap();
+    let report = engine.run(&diff).await.unwrap();
+
+    assert_eq!(report.issues.len(), 1);
+    assert_eq!(report.issues[0].file_path, "included.rs");
+}


### PR DESCRIPTION
## Summary
- filter parsed diffs using allow/deny glob patterns
- add globset dependency for path matching
- test allow and deny path configurations

## Testing
- `cargo test -p engine`


------
https://chatgpt.com/codex/tasks/task_e_68c5709932bc832d90ccf84da48c6a51