### PR TITLE
Use log macros and configure CLI verbosity

### DIFF
--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -25,10 +25,10 @@ pub struct CheckArgs {
 
 /// Executes the `check` subcommand.
 pub async fn run(args: CheckArgs, engine: &ReviewEngine) -> anyhow::Result<()> {
-    println!("Running 'check' with the following arguments:");
-    println!("  Diff base: {}", args.diff);
-    println!("  Path: {}", args.path);
-    println!("  Output: {}", args.output);
+    log::info!("Running 'check' with the following arguments:");
+    log::info!("  Diff base: {}", args.diff);
+    log::info!("  Path: {}", args.path);
+    log::info!("  Output: {}", args.output);
 
     // 1. Generate the diff against the specified base reference.
     let diff_output = Command::new("git")
@@ -53,7 +53,7 @@ pub async fn run(args: CheckArgs, engine: &ReviewEngine) -> anyhow::Result<()> {
         .generate(&report)
         .map_err(|e| anyhow::anyhow!(e))?;
     fs::write(&args.output, &report_md)?;
-    println!("\nReview complete. Report written to {}.", args.output);
+    log::info!("\nReview complete. Report written to {}.", args.output);
 
     // 4. Exit non-zero if any issues were found.
     if !report.issues.is_empty() {

--- a/crates/cli/src/commands/index.rs
+++ b/crates/cli/src/commands/index.rs
@@ -16,15 +16,15 @@ pub struct IndexArgs {
 
 /// Executes the `index` subcommand.
 pub async fn run(args: IndexArgs, _engine: &ReviewEngine) -> anyhow::Result<()> {
-    println!("Running 'index' with the following arguments:");
-    println!("  Path: {}", args.path);
-    println!("  Force: {}", args.force);
+    log::info!("Running 'index' with the following arguments:");
+    log::info!("  Path: {}", args.path);
+    log::info!("  Force: {}", args.force);
 
     // In a real implementation:
     // 1. Find all relevant files in `args.path` based on the engine's config.
     // 2. Call the engine's indexing module to create or update the RAG index.
-    println!("\nIndexing would be performed here.");
-    println!("This process would scan the codebase and populate a vector store for RAG.");
+    log::info!("\nIndexing would be performed here.");
+    log::info!("This process would scan the codebase and populate a vector store for RAG.");
 
     Ok(())
 }

--- a/crates/cli/src/commands/print_config.rs
+++ b/crates/cli/src/commands/print_config.rs
@@ -10,6 +10,6 @@ pub struct PrintConfigArgs {}
 pub fn run(_args: PrintConfigArgs, config: &Config) -> anyhow::Result<()> {
     // Serialize the config to a pretty JSON string.
     let config_json = serde_json::to_string_pretty(config)?;
-    println!("{}", config_json);
+    log::info!("{}", config_json);
     Ok(())
 }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -38,13 +38,17 @@ impl ReviewEngine {
     pub fn new(config: Config) -> Result<Self> {
         let llm = create_llm_provider(&config)?;
         let scanners = crate::scanner::load_enabled_scanners(&config);
-        Ok(Self { config,scanners, llm })
+        Ok(Self {
+            config,
+            scanners,
+            llm,
+        })
     }
 
     /// Runs a complete code review analysis on a given diff.
     pub async fn run(&self, diff: &str) -> Result<ReviewReport> {
-        println!("Engine running with config: {:?}", self.config);
-        println!("Analyzing diff: {}", diff);
+        log::info!("Engine running with config: {:?}", self.config);
+        log::debug!("Analyzing diff: {}", diff);
 
         // 1. Parse the diff to identify changed files and hunks.
         let changed_files = diff_parser::parse(diff)?;
@@ -63,7 +67,10 @@ impl ReviewEngine {
         let rag = RagContextRetriever::new(Box::new(InMemoryVectorStore::default()));
         for issue in &issues {
             let _ = rag
-                .retrieve(&format!("{}:{} {}", issue.file_path, issue.line_number, issue.description))
+                .retrieve(&format!(
+                    "{}:{} {}",
+                    issue.file_path, issue.line_number, issue.description
+                ))
                 .await?;
         }
 

--- a/crates/engine/src/rag/mod.rs
+++ b/crates/engine/src/rag/mod.rs
@@ -43,7 +43,7 @@ impl RagContextRetriever {
     }
 
     pub async fn retrieve(&self, query: &str) -> Result<String> {
-        println!("Retrieving RAG context for query: {}", query);
+        log::debug!("Retrieving RAG context for query: {}", query);
         // 1. Generate embedding for the query.
         let embedding: Vec<f32> = query.bytes().map(|b| b as f32).collect();
 


### PR DESCRIPTION
## Summary
- Replace `println!` debugging with `log` macros across engine and CLI commands
- Configure `env_logger` to honor the `--verbose` flag and output plain messages

## Testing
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_68c5709aeda4832d9f2e5ff0a4304330