### PR TITLE
refactor: simplify LLM prompt construction

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -115,24 +115,6 @@ impl ReviewEngine {
             }
         }
 
-        // 4. Call the selected LLM provider for suggestions.
-        let mut prompt = String::new();
-        if !contexts.is_empty() {
-            prompt.push_str("Context:\n");
-            prompt.push_str(&contexts.join("\n\n"));
-            prompt.push_str("\n\n");
-        }
-        prompt.push_str(&format!(
-            "Provide a review summary for the following issues: {:?}",
-            issues
-        ));
-      
-            let context = rag
-                .retrieve(&format!("{}:{} {}", issue.file_path, issue.line_number, issue.description))
-                .await?;
-            contexts.push(context);
-        }
-
         // 4. Redact issue descriptions and contexts before calling the LLM.
         let redacted_issues: Vec<String> = issues
             .iter()
@@ -154,9 +136,10 @@ impl ReviewEngine {
             redacted_contexts.join("\n")
         );
 
+        // 5. Call the selected LLM provider for suggestions.
         let llm_response = self.llm.generate(&prompt).await?;
 
-        // 5. Build and return the ReviewReport.
+        // 6. Build and return the ReviewReport.
         let report = ReviewReport {
             summary: llm_response.content,
             issues,


### PR DESCRIPTION
## Summary
- remove redundant prompt construction and extra context retrieval
- build single redacted prompt using `redacted_issues` and `redacted_contexts`

## Testing
- `cargo check -p engine`


------
https://chatgpt.com/codex/tasks/task_e_68c575419c78832dab2491ca593ff3ee