### PR TITLE
Add repository indexing persistence and docs

### DIFF
--- a/crates/cli/src/commands/index.rs
+++ b/crates/cli/src/commands/index.rs
@@ -3,6 +3,8 @@
 use clap::Args;
 use engine::rag::index_repository;
 use engine::ReviewEngine;
+use std::fs;
+use std::path::Path;
 
 #[derive(Args, Debug)]
 pub struct IndexArgs {
@@ -13,6 +15,10 @@ pub struct IndexArgs {
     /// If set, forces a full re-indexing, ignoring any existing cache.
     #[arg(long)]
     pub force: bool,
+
+    /// The path to write the generated index to.
+    #[arg(long, default_value = "index.json")]
+    pub output: String,
 }
 
 /// Executes the `index` subcommand.
@@ -20,11 +26,27 @@ pub async fn run(args: IndexArgs, _engine: &ReviewEngine) -> anyhow::Result<()> 
     log::info!("Running 'index' with the following arguments:");
     log::info!("  Path: {}", args.path);
     log::info!("  Force: {}", args.force);
+    log::info!("  Output: {}", args.output);
 
-    // In a real implementation:
-    // 1. Find all relevant files in `args.path` based on the engine's config.
-    // 2. Call the engine's indexing module to create or update the RAG index.
-    log::info!("\nIndexing would be performed here.");
-    log::info!("This process would scan the codebase and populate a vector store for RAG.");
+    // Build the index using the engine's repository indexer.
+    let store = index_repository(&args.path, args.force)
+        .await
+        .map_err(|e| anyhow::anyhow!(e))?;
+
+    // Persist the index to the requested location.
+    log::info!(
+        "Index built with {} documents. Persisting to {}",
+        store.len(),
+        args.output
+    );
+    if let Some(parent) = Path::new(&args.output).parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+    let file = fs::File::create(&args.output)?;
+    serde_json::to_writer_pretty(file, &store)?;
+    log::info!("Index written to {}", args.output);
+
     Ok(())
 }

--- a/crates/engine/src/rag/mod.rs
+++ b/crates/engine/src/rag/mod.rs
@@ -74,9 +74,16 @@ impl RagContextRetriever {
 }
 
 /// A simple in-memory vector store for demonstration purposes.
-#[derive(Default)]
+#[derive(Default, serde::Serialize, serde::Deserialize)]
 pub struct InMemoryVectorStore {
     documents: Vec<String>,
+}
+
+impl InMemoryVectorStore {
+    /// Returns the number of documents stored.
+    pub fn len(&self) -> usize {
+        self.documents.len()
+    }
 }
 
 #[async_trait]
@@ -95,7 +102,7 @@ impl VectorStore for InMemoryVectorStore {
 
 /// Indexes all files under `path` and populates an `InMemoryVectorStore`.
 pub async fn index_repository(path: &str, force: bool) -> Result<InMemoryVectorStore> {
-    println!("Indexing repository at {} (force={})", path, force);
+    log::info!("Indexing repository at {} (force={})", path, force);
     let mut store = InMemoryVectorStore::default();
 
     for entry in WalkDir::new(path).into_iter().filter_map(|e| e.ok()) {
@@ -106,5 +113,6 @@ pub async fn index_repository(path: &str, force: bool) -> Result<InMemoryVectorS
         }
     }
 
+    log::info!("Indexed {} files", store.len());
     Ok(store)
 }

--- a/docs/ci/github_action_example.yml
+++ b/docs/ci/github_action_example.yml
@@ -37,6 +37,9 @@ jobs:
     - name: Build the CLI
       run: cargo build --release
 
+    - name: Index repository
+      run: ./target/release/reviewer-cli index --path . --output index.json
+
     - name: Run code review
       id: code-review
       run: |

--- a/docs/ci/gitlab_ci_example.yml
+++ b/docs/ci/gitlab_ci_example.yml
@@ -13,6 +13,8 @@ code_review:
     - cargo test --all
     # Build the CLI
     - cargo build --release
+    # Build an index for the repository
+    - ./target/release/reviewer-cli index --path . --output index.json
     # Run the review against the target branch of the merge request
     - ./target/release/reviewer-cli check --diff $CI_MERGE_REQUEST_TARGET_BRANCH_NAME --output review_report.md
   artifacts:


### PR DESCRIPTION
## Summary
- index subcommand now builds an index via `index_repository` and saves it to a configurable JSON file
- InMemoryVectorStore supports serialization and reports document count for logging
- CI examples document how to invoke indexing before running checks

## Testing
- `cargo test --all` *(fails: unexpected closing delimiter in crates/engine/src/lib.rs:168)*

------
https://chatgpt.com/codex/tasks/task_e_68c575426e2c832db15153bdc4a033f6