### PR TITLE
Add on-disk caching for repository index

### DIFF
--- a/crates/cli/src/commands/index.rs
+++ b/crates/cli/src/commands/index.rs
@@ -1,10 +1,8 @@
 //! The `index` subcommand.
 
 use clap::Args;
-use engine::ReviewEngine;
 use engine::rag::index_repository;
-use std::fs;
-use std::path::Path;
+use engine::ReviewEngine;
 
 #[derive(Args, Debug)]
 pub struct IndexArgs {
@@ -28,25 +26,15 @@ pub async fn run(args: IndexArgs, _engine: &ReviewEngine) -> anyhow::Result<()> 
     log::info!("  Force: {}", args.force);
     log::info!("  Output: {}", args.output);
 
-    // Build the index using the engine's repository indexer.
-    let store = index_repository(&args.path, args.force)
+    // Build (or load) the index using the engine's repository indexer.
+    let store = index_repository(&args.path, &args.output, args.force)
         .await
         .map_err(|e| anyhow::anyhow!(e))?;
-
-    // Persist the index to the requested location.
     log::info!(
-        "Index built with {} documents. Persisting to {}",
+        "Index available with {} documents at {}",
         store.len(),
         args.output
     );
-    if let Some(parent) = Path::new(&args.output).parent() {
-        if !parent.as_os_str().is_empty() {
-            fs::create_dir_all(parent)?;
-        }
-    }
-    let file = fs::File::create(&args.output)?;
-    serde_json::to_writer_pretty(file, &store)?;
-    log::info!("Index written to {}", args.output);
 
     Ok(())
 }

--- a/crates/engine/tests/rag.rs
+++ b/crates/engine/tests/rag.rs
@@ -1,7 +1,8 @@
-use engine::rag::{InMemoryVectorStore, RagContextRetriever, VectorStore};
+use engine::rag::{index_repository, InMemoryVectorStore, RagContextRetriever, VectorStore};
 use std::env;
 use std::fs;
 use std::time::{SystemTime, UNIX_EPOCH};
+use tempfile::tempdir;
 
 #[tokio::test]
 async fn retrieves_context_from_saved_store() {
@@ -31,4 +32,50 @@ async fn retrieves_context_from_saved_store() {
     let rag = RagContextRetriever::new(Box::new(loaded));
     let ctx = rag.retrieve("whatever").await.unwrap();
     assert!(ctx.contains("example context"));
+}
+
+#[tokio::test]
+async fn indexes_repository_and_saves_to_disk() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("file.txt");
+    fs::write(&file_path, "content").unwrap();
+    let index_path = dir.path().join("index.json");
+
+    let store = index_repository(dir.path(), &index_path, false)
+        .await
+        .unwrap();
+
+    assert_eq!(store.len(), 1);
+    assert!(index_path.exists());
+}
+
+#[tokio::test]
+async fn uses_cached_index_when_not_forced() {
+    let dir = tempdir().unwrap();
+    let file_a = dir.path().join("a.txt");
+    fs::write(&file_a, "a").unwrap();
+    let index_dir = tempdir().unwrap();
+    let index_path = index_dir.path().join("index.json");
+
+    // Initial indexing creates the cache
+    let initial = index_repository(dir.path(), &index_path, false)
+        .await
+        .unwrap();
+    assert_eq!(initial.len(), 1);
+
+    // Add another file after the cache exists
+    let file_b = dir.path().join("b.txt");
+    fs::write(&file_b, "b").unwrap();
+
+    // Without force, the cached index should be used (still 1 document)
+    let cached = index_repository(dir.path(), &index_path, false)
+        .await
+        .unwrap();
+    assert_eq!(cached.len(), 1);
+
+    // Forcing rebuild should pick up the new file
+    let rebuilt = index_repository(dir.path(), &index_path, true)
+        .await
+        .unwrap();
+    assert_eq!(rebuilt.len(), 2);
 }


### PR DESCRIPTION
## Summary
- Support loading and saving repository indices so repeated runs can reuse a cached index
- Wire CLI `index` command to pass output path and force flag
- Test fresh and cached indexing behavior

## Testing
- `cargo test -p engine --test rag`


------
https://chatgpt.com/codex/tasks/task_e_68c57939aea0832db44a6b27d0b58bd3