### PR TITLE
Enforce LLM token budgets

### DIFF
--- a/crates/engine/src/error.rs
+++ b/crates/engine/src/error.rs
@@ -16,6 +16,9 @@ pub enum EngineError {
     #[error("LLM provider error: {0}")]
     LlmProvider(String),
 
+    #[error("Token budget exceeded: used {used} tokens but budget is {max}")]
+    TokenBudgetExceeded { used: u32, max: u32 },
+
     #[error("Scanner error: {0}")]
     Scanner(String),
 

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -72,6 +72,8 @@ impl ReviewEngine {
         log::info!("Engine running with config: {:?}", self.config);
         log::debug!("Analyzing diff: {}", diff);
 
+        let mut total_tokens_used: u32 = 0;
+
         // 1. Parse the diff to identify changed files and hunks.
         let changed_files = diff_parser::parse(diff)?;
 
@@ -99,22 +101,26 @@ impl ReviewEngine {
         }
 
         // 3. Retrieve RAG context for flagged regions.
-        let vector_store: Box<dyn VectorStore + Send + Sync> = if let Some(path) = &self.config.index_path {
-            match InMemoryVectorStore::load_from_disk(path) {
-                Ok(store) => Box::new(store),
-                Err(e) => {
-                    log::warn!("Failed to load vector index from {}: {}", path, e);
-                    Box::new(InMemoryVectorStore::default())
+        let vector_store: Box<dyn VectorStore + Send + Sync> =
+            if let Some(path) = &self.config.index_path {
+                match InMemoryVectorStore::load_from_disk(path) {
+                    Ok(store) => Box::new(store),
+                    Err(e) => {
+                        log::warn!("Failed to load vector index from {}: {}", path, e);
+                        Box::new(InMemoryVectorStore::default())
+                    }
                 }
-            }
-        } else {
-            Box::new(InMemoryVectorStore::default())
-        };
+            } else {
+                Box::new(InMemoryVectorStore::default())
+            };
         let rag = RagContextRetriever::new(vector_store);
         let mut contexts = Vec::new();
         for issue in &issues {
             if let Ok(ctx) = rag
-                .retrieve(&format!("{}:{} {}", issue.file_path, issue.line_number, issue.description))
+                .retrieve(&format!(
+                    "{}:{} {}",
+                    issue.file_path, issue.line_number, issue.description
+                ))
                 .await
             {
                 contexts.push(ctx);
@@ -155,7 +161,24 @@ impl ReviewEngine {
         );
 
         // 5. Call the selected LLM provider for suggestions.
+        if let Some(max) = self.config.budget.tokens.max_per_run {
+            if total_tokens_used >= max {
+                return Err(EngineError::TokenBudgetExceeded {
+                    used: total_tokens_used,
+                    max,
+                });
+            }
+        }
         let llm_response = self.llm.generate(&prompt).await?;
+        total_tokens_used = total_tokens_used.saturating_add(llm_response.token_usage);
+        if let Some(max) = self.config.budget.tokens.max_per_run {
+            if total_tokens_used > max {
+                return Err(EngineError::TokenBudgetExceeded {
+                    used: total_tokens_used,
+                    max,
+                });
+            }
+        }
 
         // 6. Build and return the ReviewReport.
         let report = ReviewReport {

--- a/crates/engine/src/llm/anthropic.rs
+++ b/crates/engine/src/llm/anthropic.rs
@@ -47,6 +47,14 @@ struct ContentBlock {
 #[derive(Deserialize)]
 struct AnthropicResponse {
     content: Vec<ContentBlock>,
+    #[serde(default)]
+    usage: Option<Usage>,
+}
+
+#[derive(Deserialize)]
+struct Usage {
+    input_tokens: u32,
+    output_tokens: u32,
 }
 
 #[async_trait]
@@ -79,6 +87,13 @@ impl LlmProvider for AnthropicProvider {
             .first()
             .map(|c| c.text.clone())
             .unwrap_or_default();
-        Ok(LlmResponse { content })
+        let tokens = res
+            .usage
+            .map(|u| u.input_tokens + u.output_tokens)
+            .unwrap_or(0);
+        Ok(LlmResponse {
+            content,
+            token_usage: tokens,
+        })
     }
 }

--- a/crates/engine/src/llm/deepseek.rs
+++ b/crates/engine/src/llm/deepseek.rs
@@ -47,6 +47,15 @@ struct ChatCompletionChoice {
 #[derive(Deserialize)]
 struct ChatCompletionResponse {
     choices: Vec<ChatCompletionChoice>,
+    #[serde(default)]
+    usage: Option<Usage>,
+}
+
+#[derive(Deserialize)]
+struct Usage {
+    prompt_tokens: u32,
+    completion_tokens: u32,
+    total_tokens: u32,
 }
 
 #[async_trait]
@@ -78,6 +87,10 @@ impl LlmProvider for DeepSeekProvider {
             .first()
             .map(|c| c.message.content.clone())
             .unwrap_or_default();
-        Ok(LlmResponse { content })
+        let tokens = res.usage.map(|u| u.total_tokens).unwrap_or(0);
+        Ok(LlmResponse {
+            content,
+            token_usage: tokens,
+        })
     }
 }

--- a/crates/engine/src/llm/mod.rs
+++ b/crates/engine/src/llm/mod.rs
@@ -11,7 +11,8 @@ use async_trait::async_trait;
 /// Represents a response from an LLM.
 pub struct LlmResponse {
     pub content: String,
-    // Could also include metadata like token usage, finish reason, etc.
+    /// Number of tokens consumed to generate this response.
+    pub token_usage: u32,
 }
 
 /// A trait for interacting with an LLM provider.
@@ -38,9 +39,10 @@ impl LlmProvider for NullProvider {
         log::info!("--- LLM Call (Null Provider) ---");
         log::debug!("Prompt: {}", prompt);
         log::info!("--- End LLM Call ---");
-
+        let tokens = prompt.split_whitespace().count() as u32;
         Ok(LlmResponse {
             content: "This is a dummy response from the null provider.".to_string(),
+            token_usage: tokens,
         })
     }
 }
@@ -58,11 +60,10 @@ pub fn create_llm_provider(config: &Config) -> Result<Box<dyn LlmProvider>> {
                 .api_key
                 .clone()
                 .ok_or_else(|| EngineError::Config("Missing OpenAI api_key".into()))?;
-            let model = config
-                .llm
-                .model
-                .clone()
-                .ok_or_else(|| EngineError::Config("Missing model for OpenAI provider".into()))?;
+            let model =
+                config.llm.model.clone().ok_or_else(|| {
+                    EngineError::Config("Missing model for OpenAI provider".into())
+                })?;
             let temperature = config.generation.temperature.unwrap_or(0.1);
             Ok(Box::new(openai::OpenAiProvider::new(
                 api_key,
@@ -77,13 +78,9 @@ pub fn create_llm_provider(config: &Config) -> Result<Box<dyn LlmProvider>> {
                 .api_key
                 .clone()
                 .ok_or_else(|| EngineError::Config("Missing Anthropic api_key".into()))?;
-            let model = config
-                .llm
-                .model
-                .clone()
-                .ok_or_else(|| {
-                    EngineError::Config("Missing model for Anthropic provider".into())
-                })?;
+            let model = config.llm.model.clone().ok_or_else(|| {
+                EngineError::Config("Missing model for Anthropic provider".into())
+            })?;
             let temperature = config.generation.temperature.unwrap_or(0.1);
             Ok(Box::new(anthropic::AnthropicProvider::new(
                 api_key,
@@ -98,11 +95,10 @@ pub fn create_llm_provider(config: &Config) -> Result<Box<dyn LlmProvider>> {
                 .api_key
                 .clone()
                 .ok_or_else(|| EngineError::Config("Missing DeepSeek api_key".into()))?;
-            let model = config
-                .llm
-                .model
-                .clone()
-                .ok_or_else(|| EngineError::Config("Missing model for DeepSeek provider".into()))?;
+            let model =
+                config.llm.model.clone().ok_or_else(|| {
+                    EngineError::Config("Missing model for DeepSeek provider".into())
+                })?;
             let temperature = config.generation.temperature.unwrap_or(0.1);
             Ok(Box::new(deepseek::DeepSeekProvider::new(
                 api_key,

--- a/crates/engine/src/llm/openai.rs
+++ b/crates/engine/src/llm/openai.rs
@@ -47,6 +47,15 @@ struct ChatCompletionChoice {
 #[derive(Deserialize)]
 struct ChatCompletionResponse {
     choices: Vec<ChatCompletionChoice>,
+    #[serde(default)]
+    usage: Option<Usage>,
+}
+
+#[derive(Deserialize)]
+struct Usage {
+    prompt_tokens: u32,
+    completion_tokens: u32,
+    total_tokens: u32,
 }
 
 #[async_trait]
@@ -78,6 +87,10 @@ impl LlmProvider for OpenAiProvider {
             .first()
             .map(|c| c.message.content.clone())
             .unwrap_or_default();
-        Ok(LlmResponse { content })
+        let tokens = res.usage.map(|u| u.total_tokens).unwrap_or(0);
+        Ok(LlmResponse {
+            content,
+            token_usage: tokens,
+        })
     }
 }

--- a/crates/engine/tests/budget.rs
+++ b/crates/engine/tests/budget.rs
@@ -1,0 +1,49 @@
+use engine::config::Config;
+use engine::error::EngineError;
+use engine::ReviewEngine;
+
+fn diff_for_file(path: &str, line: &str) -> String {
+    format!(
+        "diff --git a/{0} b/{0}\n--- a/{0}\n+++ b/{0}\n@@ -0,0 +1 @@\n+{1}\n",
+        path, line
+    )
+}
+
+#[tokio::test]
+async fn errors_when_token_budget_exceeded() {
+    let temp = tempfile::tempdir().unwrap();
+    let file_path = temp.path().join("file.rs");
+    let content = "fn main() {}";
+    std::fs::write(&file_path, content).unwrap();
+    let diff = diff_for_file("file.rs", content);
+
+    let mut config = Config::default();
+    config.budget.tokens.max_per_run = Some(0);
+
+    let engine = ReviewEngine::new(config).unwrap();
+
+    std::env::set_current_dir(temp.path()).unwrap();
+    match engine.run(&diff).await {
+        Err(EngineError::TokenBudgetExceeded { .. }) => {}
+        Err(other) => panic!("unexpected error: {other:?}"),
+        Ok(_) => panic!("expected budget error"),
+    }
+}
+
+#[tokio::test]
+async fn succeeds_within_token_budget() {
+    let temp = tempfile::tempdir().unwrap();
+    let file_path = temp.path().join("file.rs");
+    let content = "fn main() {}";
+    std::fs::write(&file_path, content).unwrap();
+    let diff = diff_for_file("file.rs", content);
+
+    let mut config = Config::default();
+    config.budget.tokens.max_per_run = Some(1000);
+
+    let engine = ReviewEngine::new(config).unwrap();
+
+    std::env::set_current_dir(temp.path()).unwrap();
+    let report = engine.run(&diff).await.unwrap();
+    assert!(report.summary.len() > 0 || report.issues.is_empty());
+}


### PR DESCRIPTION
## Summary
- track and accumulate token usage from each LLM invocation
- stop further calls when the configured token budget is exceeded and surface a clear error
- test token budget enforcement

## Testing
- `cargo test -p engine`

------
https://chatgpt.com/codex/tasks/task_e_68c5793ed014832d879776a41ac63796