### PR TITLE
Add aarch64 release targets and signed artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,11 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
           - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-pc-windows-msvc
             os: windows-latest
@@ -78,6 +82,17 @@ jobs:
 
       - name: List downloaded files
         run: ls -R release-assets
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Generate checksums and signatures
+        run: |
+          cd release-assets
+          for f in *; do
+            sha256sum "$f" | awk '{print $1}' > "$f.sha256"
+            cosign sign-blob --yes "$f" --output-signature "$f.sig"
+          done
 
       - name: Create Release
         uses: softprops/action-gh-release@v1

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ You can download pre-compiled binaries directly from the [GitHub Releases page](
 
 Download the appropriate archive for your operating system, extract it, and place the `reviewer-cli` (or `reviewer-cli.exe`) binary in a directory included in your system's `PATH`.
 
+Each release also provides a `.sha256` checksum and a `.sig` signature file generated with [cosign](https://github.com/sigstore/cosign). After downloading an archive, you can verify its integrity and authenticity:
+
+```bash
+# Verify the checksum
+sha256sum -c reviewer-cli-<TARGET>.tar.gz.sha256
+
+# Verify the signature (requires cosign)
+cosign verify-blob --signature reviewer-cli-<TARGET>.tar.gz.sig reviewer-cli-<TARGET>.tar.gz
+```
+
 ### With `cargo` (Requires Rust)
 
 If you have the Rust toolchain installed, you can build and install `reviewer-cli` from crates.io.

--- a/install.sh
+++ b/install.sh
@@ -48,11 +48,14 @@ case "$OS" in
 esac
 
 case "$ARCH" in
-    x86_64)
+    x86_64|amd64)
         TARGET_ARCH="x86_64"
         ;;
+    aarch64|arm64)
+        TARGET_ARCH="aarch64"
+        ;;
     *)
-        print_error "Unsupported architecture: ${ARCH}. Only x86_64 is currently supported."
+        print_error "Unsupported architecture: ${ARCH}. Only x86_64 and aarch64 are currently supported."
         ;;
 esac
 


### PR DESCRIPTION
## Summary
- build release binaries for aarch64 Linux and macOS
- sign release artifacts and provide SHA256 checksums
- support aarch64 in install script and document verifying signatures

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c57e963b0c832daa0bfc231da92c94