### PR TITLE
Add Go server XSS scanner

### DIFF
--- a/crates/engine/src/config.rs
+++ b/crates/engine/src/config.rs
@@ -211,6 +211,8 @@ pub struct RulesConfig {
     pub http_timeouts_go: RuleConfig,
     #[serde(default)]
     pub convention_deviation: RuleConfig,
+    #[serde(default)]
+    pub server_xss_go: RuleConfig,
 }
 
 impl Config {

--- a/crates/engine/src/scanner/mod.rs
+++ b/crates/engine/src/scanner/mod.rs
@@ -37,6 +37,8 @@ pub mod secrets;
 pub use secrets::SecretsScanner;
 pub mod convention_deviation;
 pub use convention_deviation::ConventionDeviationScanner;
+pub mod server_xss_go;
+pub use server_xss_go::ServerXssGoScanner;
 
 static SQL_INJECTION_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
     vec![
@@ -129,6 +131,7 @@ fn register_builtin_scanners() {
         register_scanner("convention-deviation", || {
             Box::new(ConventionDeviationScanner)
         });
+        register_scanner("server-xss-go", || Box::new(ServerXssGoScanner));
     });
 }
 
@@ -155,6 +158,11 @@ pub fn load_enabled_scanners(config: &Config) -> Vec<Box<dyn Scanner>> {
     }
     if config.rules.convention_deviation.enabled {
         if let Some(factory) = registry.get("convention-deviation") {
+            scanners.push(factory());
+        }
+    }
+    if config.rules.server_xss_go.enabled {
+        if let Some(factory) = registry.get("server-xss-go") {
             scanners.push(factory());
         }
     }

--- a/crates/engine/src/scanner/server_xss_go.rs
+++ b/crates/engine/src/scanner/server_xss_go.rs
@@ -1,0 +1,50 @@
+use crate::config::Config;
+use crate::error::Result;
+use crate::scanner::{Issue, Scanner};
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+pub struct ServerXssGoScanner;
+
+static TEXT_TEMPLATE_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?i)text/template").unwrap());
+static UNSAFE_WRITE_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r"(?i)(w\.Write|fmt\.Fprintf\(w|io\.WriteString\(w)[^\n]*(r\.FormValue|r\.URL\.Query\(\)\.Get|r\.Form\.Get)"
+    )
+    .unwrap()
+});
+
+impl Scanner for ServerXssGoScanner {
+    fn name(&self) -> &'static str {
+        "Server XSS Scanner (Go)"
+    }
+
+    fn scan(&self, file_path: &str, content: &str, config: &Config) -> Result<Vec<Issue>> {
+        let mut issues = Vec::new();
+        for (i, line) in content.lines().enumerate() {
+            if TEXT_TEMPLATE_REGEX.is_match(line) {
+                issues.push(Issue {
+                    title: "text/template used for HTML".to_string(),
+                    description:
+                        "text/template does not auto-escape HTML; use html/template instead."
+                            .to_string(),
+                    file_path: file_path.to_string(),
+                    line_number: i + 1,
+                    severity: config.rules.server_xss_go.severity.clone(),
+                });
+            }
+            if UNSAFE_WRITE_REGEX.is_match(line) {
+                issues.push(Issue {
+                    title: "Unescaped user input written to ResponseWriter".to_string(),
+                    description:
+                        "Writing untrusted input directly to http.ResponseWriter can lead to XSS."
+                            .to_string(),
+                    file_path: file_path.to_string(),
+                    line_number: i + 1,
+                    severity: config.rules.server_xss_go.severity.clone(),
+                });
+            }
+        }
+        Ok(issues)
+    }
+}

--- a/crates/engine/tests/server_xss_go.rs
+++ b/crates/engine/tests/server_xss_go.rs
@@ -1,0 +1,53 @@
+use engine::config::Config;
+use engine::scanner::{Scanner, ServerXssGoScanner};
+
+#[test]
+fn detects_text_template_usage() {
+    let scanner = ServerXssGoScanner;
+    let content = r#"
+        import "text/template"
+        func handler(w http.ResponseWriter, r *http.Request) {
+            tmpl := template.New("foo")
+            tmpl.Execute(w, r.FormValue("name"))
+        }
+    "#;
+    let config = Config::default();
+    let issues = scanner
+        .scan("handler.go", content, &config)
+        .expect("scan should work");
+    assert_eq!(issues.len(), 1);
+    assert_eq!(issues[0].line_number, 2);
+}
+
+#[test]
+fn detects_unescaped_input_written() {
+    let scanner = ServerXssGoScanner;
+    let content = r#"
+        func handler(w http.ResponseWriter, r *http.Request) {
+            w.Write([]byte(r.FormValue("name")))
+        }
+    "#;
+    let config = Config::default();
+    let issues = scanner
+        .scan("handler.go", content, &config)
+        .expect("scan should work");
+    assert_eq!(issues.len(), 1);
+    assert_eq!(issues[0].line_number, 3);
+}
+
+#[test]
+fn allows_html_template() {
+    let scanner = ServerXssGoScanner;
+    let content = r#"
+        import "html/template"
+        func handler(w http.ResponseWriter, r *http.Request) {
+            tmpl := template.Must(template.New("foo").Parse("<p>{{.}}</p>"))
+            tmpl.Execute(w, r.FormValue("name"))
+        }
+    "#;
+    let config = Config::default();
+    let issues = scanner
+        .scan("handler.go", content, &config)
+        .expect("scan should work");
+    assert!(issues.is_empty());
+}

--- a/docs/server_xss_go.md
+++ b/docs/server_xss_go.md
@@ -1,0 +1,23 @@
+# server-xss-go
+
+Detects potential server-side cross-site scripting (XSS) vulnerabilities in Go
+HTTP handlers. The scanner flags two common issues:
+
+1. Using `text/template` for HTML responses instead of `html/template`, which
+   does not provide automatic HTML escaping.
+2. Writing untrusted input directly to `http.ResponseWriter` without proper
+   escaping or templating, such as `w.Write([]byte(r.FormValue("name")))`.
+
+## Recommendation
+
+Use `html/template` for any HTML output and ensure user input is properly
+escaped before writing it to the response. Avoid writing request parameters
+directly using `fmt.Fprintf`, `io.WriteString`, or `w.Write`.
+
+## Configuration
+
+```toml
+[rules.server-xss-go]
+enabled = true
+severity = "medium"
+```

--- a/reviewer.toml.example
+++ b/reviewer.toml.example
@@ -69,3 +69,7 @@ severity = "medium"
 enabled = true
 severity = "medium"
 
+[rules.server-xss-go]
+enabled = true
+severity = "medium"
+


### PR DESCRIPTION
## Summary
- detect unescaped HTML responses in Go servers with new `server-xss-go` scanner
- document and expose configuration for the new rule

## Testing
- `cargo test`
- `cargo test --test server_xss_go`


------
https://chatgpt.com/codex/tasks/task_e_68c57e8b317c832d8b465e997010326a