### PR TITLE
Use patch crate for diff parsing and expand tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ The project is structured as a Cargo workspace:
 -   `crates/cli`: A thin wrapper around the `engine` that provides a command-line interface.
 -   `reviewer.toml`: The configuration file for defining project rules, LLM providers, and other settings.
 
+## Supported Diff Formats
+
+The engine uses the [`patch`](https://crates.io/crates/patch) crate to parse diffs in the unified format. It understands
+standard text diffs, file renames, binary file changes, and multiple hunks within a single file.
+
 ---
 
 *This project was bootstrapped by an AI agent.*

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -29,6 +29,7 @@ regex = "1.10"
 once_cell = "1"
 clap = { version = "4.5", features = ["derive"] }
 globset = "0.4"
+patch = "0.7"
 
 [features]
 default = []

--- a/crates/engine/src/diff_parser.rs
+++ b/crates/engine/src/diff_parser.rs
@@ -1,6 +1,7 @@
 //! Logic for parsing diffs to identify changed files and hunks.
 
 use crate::error::{EngineError, Result};
+use patch::{Line as PatchLine, Patch};
 
 /// Represents a single changed file in a diff.
 #[derive(Debug)]
@@ -27,7 +28,7 @@ pub enum Line {
     Context(String),
 }
 
-/// Parses a raw diff string into a structured format.
+/// Parses a raw diff string into a structured format using the `patch` crate.
 ///
 /// # Arguments
 ///
@@ -35,132 +36,84 @@ pub enum Line {
 ///
 /// # Returns
 ///
-/// A `Result` containing a vector of `ChangedFile`s or a `DiffParserError`.
+/// A `Result` containing a vector of `ChangedFile`s or an `EngineError`.
 pub fn parse(diff_text: &str) -> Result<Vec<ChangedFile>> {
-    // A real implementation would use a proper diff parsing library (e.g., `diffy` or similar)
-    // or parse the unified diff format manually.
     if diff_text.trim().is_empty() {
         return Ok(Vec::new());
     }
 
     let mut files = Vec::new();
-    let mut lines = diff_text.lines().peekable();
+    let mut segment = String::new();
 
-    while let Some(line) = lines.next() {
+    for line in diff_text.lines() {
         if line.starts_with("diff --git ") {
-            let tokens: Vec<&str> = line.split_whitespace().collect();
-            if tokens.len() < 4 {
-                return Err(EngineError::DiffParser("Malformed diff header".into()));
+            if !segment.is_empty() {
+                files.push(parse_segment(&segment)?);
+                segment.clear();
             }
-            let path = tokens[3].trim_start_matches("b/").to_string();
-
-            // Advance to the file markers "---" and "+++"
-            while let Some(l) = lines.next() {
-                if l.starts_with("--- ") {
-                    break;
-                }
-            }
-
-            let plus_line = lines
-                .next()
-                .ok_or_else(|| EngineError::DiffParser("Missing +++ line".into()))?;
-            if !plus_line.starts_with("+++ ") {
-                return Err(EngineError::DiffParser("Missing +++ line".into()));
-            }
-
-            let mut hunks = Vec::new();
-            while let Some(peek) = lines.peek() {
-                if peek.starts_with("diff --git ") {
-                    break;
-                }
-                if peek.starts_with("@@") {
-                    let header = lines.next().unwrap();
-                    let hunk = parse_hunk(header, &mut lines)?;
-                    hunks.push(hunk);
-                } else {
-                    // Skip any other metadata lines
-                    lines.next();
-                }
-            }
-
-            files.push(ChangedFile { path, hunks });
         }
+        segment.push_str(line);
+        segment.push('\n');
+    }
+
+    if !segment.is_empty() {
+        files.push(parse_segment(&segment)?);
     }
 
     Ok(files)
 }
 
-fn parse_hunk<'a, I>(header: &str, lines: &mut std::iter::Peekable<I>) -> Result<Hunk>
-where
-    I: Iterator<Item = &'a str>,
-{
-    // Header example: "@@ -1,3 +1,3 @@"
-    let header = header.trim();
-    if !header.starts_with("@@") {
-        return Err(EngineError::DiffParser("Invalid hunk header".into()));
+fn parse_segment(segment: &str) -> Result<ChangedFile> {
+    let header_path = segment
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(3))
+        .ok_or_else(|| EngineError::DiffParser("Malformed diff header".into()))?
+        .trim_start_matches("b/")
+        .to_string();
+
+    let has_patch = segment.lines().any(|l| l.starts_with("--- "));
+    let is_binary = segment
+        .lines()
+        .any(|l| l.starts_with("Binary files") || l.starts_with("GIT binary patch"));
+
+    if !has_patch || is_binary {
+        return Ok(ChangedFile {
+            path: header_path,
+            hunks: Vec::new(),
+        });
     }
 
-    let header = header
-        .trim_start_matches("@@")
-        .trim_end_matches("@@")
-        .trim();
-
-    let mut parts = header.split(' ');
-    let old_part = parts
+    let patches =
+        Patch::from_multiple(segment).map_err(|e| EngineError::DiffParser(e.to_string()))?;
+    let patch = patches
+        .into_iter()
         .next()
-        .ok_or_else(|| EngineError::DiffParser("Missing old range".into()))?;
-    let new_part = parts
-        .next()
-        .ok_or_else(|| EngineError::DiffParser("Missing new range".into()))?;
+        .ok_or_else(|| EngineError::DiffParser("No patch data found".into()))?;
 
-    let (old_start, old_lines) = parse_range(old_part.trim_start_matches('-'))?;
-    let (new_start, new_lines) = parse_range(new_part.trim_start_matches('+'))?;
-
-    let mut hunk_lines = Vec::new();
-    while let Some(peek) = lines.peek() {
-        if peek.starts_with("@@") || peek.starts_with("diff --git ") {
-            break;
-        }
-        let l = lines.next().unwrap();
-        let mut chars = l.chars();
-        match chars.next() {
-            Some('+') => hunk_lines.push(Line::Added(chars.as_str().to_string())),
-            Some('-') => hunk_lines.push(Line::Removed(chars.as_str().to_string())),
-            Some(' ') => hunk_lines.push(Line::Context(chars.as_str().to_string())),
-            Some('\\') => hunk_lines.push(Line::Context(l.to_string())),
-            Some(other) => {
-                return Err(EngineError::DiffParser(format!(
-                    "Invalid line in hunk: starts with '{}'",
-                    other
-                )))
+    let path = patch.new.path.trim_start_matches("b/").to_string();
+    let hunks = patch
+        .hunks
+        .into_iter()
+        .map(|h| {
+            let lines = h
+                .lines
+                .into_iter()
+                .map(|l| match l {
+                    PatchLine::Add(s) => Line::Added(s.to_string()),
+                    PatchLine::Remove(s) => Line::Removed(s.to_string()),
+                    PatchLine::Context(s) => Line::Context(s.to_string()),
+                })
+                .collect();
+            Hunk {
+                old_start: h.old_range.start as u32,
+                old_lines: h.old_range.count as u32,
+                new_start: h.new_range.start as u32,
+                new_lines: h.new_range.count as u32,
+                lines,
             }
-            None => hunk_lines.push(Line::Context(String::new())),
-        }
-    }
-
-    Ok(Hunk {
-        old_start,
-        old_lines,
-        new_start,
-        new_lines,
-        lines: hunk_lines,
-    })
-}
-
-fn parse_range(range: &str) -> Result<(u32, u32)> {
-    let mut it = range.split(',');
-    let start = it
-        .next()
-        .ok_or_else(|| EngineError::DiffParser("Missing range start".into()))?
-        .parse::<u32>()
-        .map_err(|_| EngineError::DiffParser("Invalid range start".into()))?;
-    let lines = it
-        .next()
-        .map(|s| {
-            s.parse::<u32>()
-                .map_err(|_| EngineError::DiffParser("Invalid range length".into()))
         })
-        .transpose()?
-        .unwrap_or(1);
-    Ok((start, lines))
+        .collect();
+
+    Ok(ChangedFile { path, hunks })
 }

--- a/crates/engine/tests/diff_parser.rs
+++ b/crates/engine/tests/diff_parser.rs
@@ -39,3 +39,75 @@ fn parse_simple_unified_diff() {
     assert!(matches!(&hunk.lines[2], Line::Added(line) if line == "line2modified"));
     assert!(matches!(&hunk.lines[3], Line::Added(line) if line == "line3"));
 }
+
+#[test]
+fn parse_rename_diff_without_changes() {
+    let diff = r#"diff --git a/old.txt b/new.txt
+similarity index 100%
+rename from old.txt
+rename to new.txt
+"#;
+
+    let files = diff_parser::parse(diff).expect("should parse");
+    assert_eq!(files.len(), 1);
+    let file = &files[0];
+    assert_eq!(file.path, "new.txt");
+    assert!(file.hunks.is_empty());
+}
+
+#[test]
+fn parse_binary_file_diff() {
+    let diff = r#"diff --git a/image.png b/image.png
+new file mode 100644
+index 0000000..e69de29
+Binary files /dev/null and b/image.png differ
+"#;
+
+    let files = diff_parser::parse(diff).expect("should parse");
+    assert_eq!(files.len(), 1);
+    let file = &files[0];
+    assert_eq!(file.path, "image.png");
+    assert!(file.hunks.is_empty());
+}
+
+#[test]
+fn parse_multiple_hunks() {
+    use engine::diff_parser::Line;
+
+    let diff = r#"diff --git a/foo.txt b/foo.txt
+--- a/foo.txt
++++ b/foo.txt
+@@ -1,2 +1,2 @@
+-line1
+-line2
++line1mod
++line2
+@@ -4,2 +4,3 @@
+ line4
+-line5
++line5mod
++line6
+"#;
+
+    let files = diff_parser::parse(diff).expect("should parse");
+    assert_eq!(files.len(), 1);
+    let file = &files[0];
+    assert_eq!(file.hunks.len(), 2);
+
+    // Verify first hunk
+    let h1 = &file.hunks[0];
+    assert_eq!(h1.old_start, 1);
+    assert_eq!(h1.new_start, 1);
+    assert_eq!(h1.lines.len(), 4);
+    assert!(matches!(h1.lines[0], Line::Removed(ref l) if l == "line1"));
+    assert!(matches!(h1.lines[2], Line::Added(ref l) if l == "line1mod"));
+
+    // Verify second hunk
+    let h2 = &file.hunks[1];
+    assert_eq!(h2.old_start, 4);
+    assert_eq!(h2.new_start, 4);
+    assert_eq!(h2.lines.len(), 4);
+    assert!(matches!(h2.lines[1], Line::Removed(ref l) if l == "line5"));
+    assert!(matches!(h2.lines[2], Line::Added(ref l) if l == "line5mod"));
+    assert!(matches!(h2.lines[3], Line::Added(ref l) if l == "line6"));
+}


### PR DESCRIPTION
## Summary
- parse diffs using patch crate instead of manual logic
- add tests for rename, binary files, and multiple hunks
- document supported diff formats

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c57e94171c832d8b04dbf3c18fe9d0