### PR TITLE
feat(cli): add base-ref option and exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For a containerized environment, you can use Docker.
 2.  **Run the container:**
     You'll need to mount your project directory and pass your configuration.
     ```bash
-    docker run --rm -v "$(pwd):/work" reviewer-cli check --diff main
+    docker run --rm -v "$(pwd):/work" reviewer-cli check --base-ref main
     ```
 
 ### From Source
@@ -96,7 +96,7 @@ The primary command is `reviewer-cli check`. It analyzes the difference between 
 Run a review from the root of your project:
 ```bash
 # Run a review against the 'main' branch
-reviewer-cli check --diff main
+reviewer-cli check --base-ref main
 ```
 
 The review report will be saved to `review_report.md` by default. You can view it with:

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -2,6 +2,7 @@
 
 use clap::Args;
 use engine::config::Severity;
+use engine::error::EngineError;
 use engine::report::{MarkdownGenerator, ReportGenerator};
 use engine::ReviewEngine;
 use std::env;
@@ -12,9 +13,10 @@ use anyhow::Context;
 
 #[derive(Args, Debug)]
 pub struct CheckArgs {
-    /// The base branch to compare against for generating a diff.
-    #[arg(long, default_value = "main")]
-    pub diff: String,
+    /// The base reference to compare against for generating a diff.
+    /// If not provided, the upstream of the current branch is used.
+    #[arg(long, alias = "diff")]
+    pub base_ref: Option<String>,
 
     /// The path to the repository to check.
     #[arg(long, default_value = ".")]
@@ -30,15 +32,71 @@ pub struct CheckArgs {
 }
 
 /// Executes the `check` subcommand.
-pub async fn run(args: CheckArgs, engine: &ReviewEngine) -> anyhow::Result<()> {
+/// Returns the appropriate exit code.
+pub async fn run(args: CheckArgs, engine: &ReviewEngine) -> i32 {
+    match execute(args, engine).await {
+        Ok(issues_found) => {
+            if issues_found {
+                1
+            } else {
+                0
+            }
+        }
+        Err(e) => {
+            if let Some(engine_error) = e.downcast_ref::<EngineError>() {
+                match engine_error {
+                    EngineError::Config(_) => {
+                        log::error!("{}", e);
+                        3
+                    }
+                    _ => {
+                        log::error!("{}", e);
+                        2
+                    }
+                }
+            } else {
+                log::error!("{}", e);
+                2
+            }
+        }
+    }
+}
+
+async fn execute(args: CheckArgs, engine: &ReviewEngine) -> anyhow::Result<bool> {
     log::info!("Running 'check' with the following arguments:");
-    log::info!("  Diff base: {}", args.diff);
     log::info!("  Path: {}", args.path);
     log::info!("  Output: {}", args.output);
 
-    // 1. Generate the diff against the specified base reference.
+    // Resolve the base reference, falling back to upstream if not provided.
+    let base_ref = if let Some(base) = args.base_ref.clone() {
+        base
+    } else {
+        let upstream_output = Command::new("git")
+            .args([
+                "-C",
+                &args.path,
+                "rev-parse",
+                "--abbrev-ref",
+                "--symbolic-full-name",
+                "@{u}",
+            ])
+            .output()
+            .map_err(|e| {
+                EngineError::Config(format!("failed to detect upstream base: {}", e))
+            })?;
+        if !upstream_output.status.success() {
+            return Err(EngineError::Config("failed to detect upstream base reference".into()).into());
+        }
+        String::from_utf8(upstream_output.stdout)
+            .context("upstream output was not valid UTF-8")?
+            .trim()
+            .to_string()
+    };
+    log::info!("  Base ref: {}", base_ref);
+
+    // 1. Generate the diff against the base reference.
     let diff_output = Command::new("git")
-        .args(["-C", &args.path, "diff", &args.diff])
+        .args(["-C", &args.path, "diff", &base_ref])
         .output()
         .with_context(|| "failed to execute git diff")?;
     if !diff_output.status.success() {
@@ -70,7 +128,8 @@ pub async fn run(args: CheckArgs, engine: &ReviewEngine) -> anyhow::Result<()> {
     fs::write(&args.output, &report_md)?;
     log::info!("\nReview complete. Report written to {}.", args.output);
 
-    // 4. Exit non-zero based on severity threshold.
+    // 4. Determine if issues exceed the severity threshold.
+    let mut issues_found = false;
     if let Some(threshold) = args.fail_on {
         let max_severity = report
             .issues
@@ -79,13 +138,10 @@ pub async fn run(args: CheckArgs, engine: &ReviewEngine) -> anyhow::Result<()> {
             .max();
         if let Some(max) = max_severity {
             if max >= threshold {
-                anyhow::bail!(
-                    "Issues of severity {:?} or higher were found in the diff",
-                    threshold
-                );
+                issues_found = true;
             }
         }
     }
 
-    Ok(())
+    Ok(issues_found)
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -89,7 +89,10 @@ async fn main() -> anyhow::Result<()> {
 
     // Execute the subcommand
     match cli.command {
-        Commands::Check(args) => commands::check::run(args, &engine).await?,
+        Commands::Check(args) => {
+            let code = commands::check::run(args, &engine).await;
+            std::process::exit(code);
+        }
         Commands::Index(args) => commands::index::run(args, &engine).await?,
         Commands::PrintConfig(_) => {
             // This case is handled above, but the compiler needs it to be exhaustive.

--- a/crates/cli/tests/smoke.rs
+++ b/crates/cli/tests/smoke.rs
@@ -75,9 +75,107 @@ fn check_command_respects_path_argument() {
 
     let mut cmd = Command::cargo_bin("reviewer-cli").unwrap();
     cmd.args([
-        "check", "--path", repo_str, "--diff", "HEAD", "--output", output_str,
+        "check",
+        "--path",
+        repo_str,
+        "--base-ref",
+        "HEAD",
+        "--output",
+        output_str,
     ]);
 
-    cmd.assert().success();
+    cmd.assert().code(0);
     assert!(output_path.exists());
+}
+
+#[test]
+fn check_command_reports_issues_and_exit_code() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path();
+    let repo_str = repo.to_str().unwrap();
+
+    // Initialize git repository
+    StdCommand::new("git")
+        .args(["init", repo_str])
+        .output()
+        .expect("git init failed");
+    StdCommand::new("git")
+        .args(["-C", repo_str, "config", "user.email", "you@example.com"])
+        .output()
+        .expect("git config email failed");
+    StdCommand::new("git")
+        .args(["-C", repo_str, "config", "user.name", "Your Name"])
+        .output()
+        .expect("git config name failed");
+
+    // Create initial commit
+    fs::write(repo.join("file.txt"), "hello\n").unwrap();
+    StdCommand::new("git")
+        .args(["-C", repo_str, "add", "."])
+        .output()
+        .expect("git add failed");
+    StdCommand::new("git")
+        .args(["-C", repo_str, "commit", "-m", "init"])
+        .output()
+        .expect("git commit failed");
+
+    // Modify file to introduce a secret
+    fs::write(
+        repo.join("file.txt"),
+        "api_key = \"ABCDEFGHIJKLMNOP\"\n",
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("reviewer-cli").unwrap();
+    cmd.args([
+        "check",
+        "--path",
+        repo_str,
+        "--base-ref",
+        "HEAD",
+        "--fail-on",
+        "low",
+    ]);
+
+    cmd.assert().code(1);
+}
+
+#[test]
+fn check_command_without_upstream_or_base_ref_errors() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path();
+    let repo_str = repo.to_str().unwrap();
+
+    // Initialize git repository without remote
+    StdCommand::new("git")
+        .args(["init", repo_str])
+        .output()
+        .expect("git init failed");
+    StdCommand::new("git")
+        .args(["-C", repo_str, "config", "user.email", "you@example.com"])
+        .output()
+        .expect("git config email failed");
+    StdCommand::new("git")
+        .args(["-C", repo_str, "config", "user.name", "Your Name"])
+        .output()
+        .expect("git config name failed");
+
+    // Create initial commit
+    fs::write(repo.join("file.txt"), "hello\n").unwrap();
+    StdCommand::new("git")
+        .args(["-C", repo_str, "add", "."])
+        .output()
+        .expect("git add failed");
+    StdCommand::new("git")
+        .args(["-C", repo_str, "commit", "-m", "init"])
+        .output()
+        .expect("git commit failed");
+
+    // Modify file to create diff
+    fs::write(repo.join("file.txt"), "hello world\n").unwrap();
+
+    let mut cmd = Command::cargo_bin("reviewer-cli").unwrap();
+    cmd.args(["check", "--path", repo_str]);
+
+    cmd.assert().code(3);
 }

--- a/docs/ci/github_action_example.yml
+++ b/docs/ci/github_action_example.yml
@@ -45,7 +45,7 @@ jobs:
       run: |
         # Use the PR's base branch as the diff target
         BASE_BRANCH="origin/${{ github.base_ref }}"
-        ./target/release/reviewer-cli check --diff $BASE_BRANCH --output review_report.md
+        ./target/release/reviewer-cli check --base-ref $BASE_BRANCH --output review_report.md
       # Continue even if the check fails, so we can upload the report
       continue-on-error: true
 

--- a/docs/ci/gitlab_ci_example.yml
+++ b/docs/ci/gitlab_ci_example.yml
@@ -16,7 +16,7 @@ code_review:
     # Build an index for the repository (outputs index.json by default)
     - ./target/release/reviewer-cli index --path .
     # Run the review against the target branch of the merge request
-    - ./target/release/reviewer-cli check --diff $CI_MERGE_REQUEST_TARGET_BRANCH_NAME --output review_report.md
+    - ./target/release/reviewer-cli check --base-ref $CI_MERGE_REQUEST_TARGET_BRANCH_NAME --output review_report.md
   artifacts:
     paths:
       - review_report.md


### PR DESCRIPTION
## Summary
- add `--base-ref` flag with upstream default for `check`
- map review outcomes to exit codes
- document new flag and update CI templates
- test `check` exit codes and base-ref behavior

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c57e8eb2d4832dac7436854541edbc