### PR TITLE
Add quickstart, configuration, and troubleshooting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ You can run the agent in your CI pipeline to automatically review merge requests
 
 See the `docs/ci/` directory for example configurations for GitHub Actions and GitLab CI.
 
+## Documentation
+- [Quickstart](docs/quickstart.md) – install and run the agent, including CI setup and privacy defaults.
+- [Configuration](docs/config.md) – list of options and default privacy settings.
+- [Troubleshooting](docs/troubleshooting.md) – common errors and fixes.
+
 ## Architecture
 
 The project is structured as a Cargo workspace:

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,45 @@
+# Configuration
+
+`reviewer.toml` controls how the agent behaves. Values are merged in this order of precedence:
+1. CLI flags
+2. Environment variables (prefixed with `REVIEWER_`)
+3. Settings in `reviewer.toml`
+
+## Paths
+Define which files are scanned:
+```toml
+[paths]
+allow = ["src/**/*.rs", "crates/**/*.rs"]
+deny  = ["target/*", "**/testdata/*"]
+```
+Only files in `paths.allow` are indexed, helping enforce repository boundaries.
+
+## LLM Provider
+```toml
+[llm]
+provider = "null"
+model = "gpt-4-turbo"
+# api_key = "YOUR_API_KEY"
+```
+Set `provider` and `api_key` to use a remote model. The default `provider = "null"` keeps all analysis local.
+
+## Privacy
+```toml
+[privacy.redaction]
+enabled = true
+patterns = []
+```
+Secret redaction is enabled by default, and additional patterns can be supplied. Combine this with path allowlists to ensure code privacy.
+
+## Budget and Generation
+Optional sections let you cap token usage or adjust generation parameters:
+```toml
+[budget.tokens]
+# max-per-run = 100000
+
+[generation]
+temperature = 0.2
+```
+
+## Using in CI
+Supply sensitive values such as API keys via environment variables in your CI system. Example GitHub Actions and GitLab CI files live in [`docs/ci/`](ci/).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,34 @@
+# Quickstart
+
+This guide helps you install and run the `reviewer-cli` locally or in CI.
+
+## Installation
+- Use the install script:
+  ```bash
+  curl -fsSL https://raw.githubusercontent.com/some-org/intelligent-code-reviewer/main/install.sh | sh
+  ```
+- Download a release binary and place it in your `PATH`.
+- Or build from source with `cargo install`.
+
+## Configuration
+1. Copy the example file:
+   ```bash
+   cp reviewer.toml.example reviewer.toml
+   ```
+2. Set your LLM provider and API key. Configuration values can also be supplied via environment variables or CLI flags.
+
+## Running a Review
+Run the agent from the root of your project:
+```bash
+reviewer-cli check --base-ref main
+```
+The report is written to `review_report.md`.
+
+## CI Setup
+The CLI can gate pull requests by exiting non‑zero when issues are found. See the sample configurations in [`docs/ci/`](ci/) for GitHub Actions and GitLab CI examples.
+
+## Privacy Defaults
+The tool is designed with privacy in mind:
+- Only files listed in `paths.allow` are analyzed.
+- Secret redaction is enabled by default (`privacy.redaction.enabled = true`).
+- The example configuration uses `provider = "null"`, so no code is sent to an external LLM unless you explicitly configure one.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,24 @@
+# Troubleshooting
+
+Common issues and their fixes.
+
+## Missing API Key
+The CLI will report an authentication error if no API key is supplied for a remote provider. Set `REVIEWER_LLM_API_KEY` or add `api_key` to `reviewer.toml`.
+
+## Unsupported Provider or Model
+If the provider or model name is incorrect, the CLI exits with an error. Check the values in your configuration match a supported provider and model.
+
+## No Files Reviewed
+When `reviewer-cli` reports that no files were analyzed, verify that `paths.allow` includes the files you expect and that they exist in the repository.
+
+## Network Errors
+Connectivity problems can cause requests to fail. If you need an offline run, keep `provider = "null"` to use the built-in local mode.
+
+## CI Failures
+In CI environments ensure:
+- The repository is checked out before running the CLI.
+- Required secrets such as API keys are provided as environment variables.
+- The exit code is handled to block merges when issues are found.
+
+## Privacy Concerns
+By default, only allow‑listed paths are scanned and sensitive content is redacted. If data appears in logs, review your allowlist and redaction patterns.


### PR DESCRIPTION
## Summary
- Add Quickstart guide covering installation, CI setup, and privacy defaults
- Document configuration options including default privacy settings
- Provide troubleshooting tips for common errors
- Link new docs from README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c5826cfd18832d998eaf2dd93bd15f