### PR TITLE
Clarify provider config defaults and server XSS rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The agent is controlled by a `reviewer.toml` file. Copy the example file to the 
 cp reviewer.toml.example reviewer.toml
 ```
 
-Next, edit `reviewer.toml` to configure your desired LLM provider, model, project paths, and review rules. At a minimum, you must set your LLM provider and API key.
+Next, edit `reviewer.toml` to configure your desired LLM provider, model, project paths, and review rules. For any provider other than `null`, you must explicitly set both a `model` and an `api_key`.
 
 Configuration values are merged from multiple sources. The precedence is:
 

--- a/reviewer.toml
+++ b/reviewer.toml
@@ -20,8 +20,7 @@ deny = ["target/*", "**/testdata/*"]
 # "null" uses a dummy provider for offline/testing mode.
 provider = "null"
 
-# The specific model to use for analysis (e.g., "gpt-4-turbo", "claude-3-opus-20240229").
-model = "gpt-4-turbo"
+# For non-null providers, set both `model` and `api_key`.
 
 # API key for the selected provider. Required for non-null providers.
 # api_key = "YOUR_API_KEY"
@@ -39,7 +38,7 @@ model = "gpt-4-turbo"
 # --- Generation Settings ---
 [generation]
 # Controls generation behaviour such as temperature.
-temperature = 0.2
+temperature = 0
 
 
 # --- Privacy Settings ---
@@ -64,6 +63,10 @@ enabled = true
 severity = "medium"
 
 [rules.convention-deviation]
+enabled = true
+severity = "medium"
+
+[rules.server-xss-go]
 enabled = true
 severity = "medium"
 

--- a/reviewer.toml.example
+++ b/reviewer.toml.example
@@ -22,8 +22,7 @@ deny = ["target/*", "**/testdata/*"]
 # "null" uses a dummy provider for offline/testing mode.
 provider = "null"
 
-# The specific model to use for analysis (e.g., "gpt-4-turbo", "claude-3-opus-20240229").
-model = "gpt-4-turbo"
+# For non-null providers, set both `model` and `api_key`.
 
 # API key for the selected provider. Required for non-null providers.
 # api_key = "YOUR_API_KEY"
@@ -41,7 +40,7 @@ model = "gpt-4-turbo"
 # --- Generation Settings ---
 [generation]
 # Controls generation behaviour such as temperature.
-temperature = 0.2
+temperature = 0
 
 
 # --- Privacy Settings ---


### PR DESCRIPTION
## Summary
- omit `model` when provider is `null` and set generation temperature to 0
- add `server-xss-go` rule to default configs and document provider requirements

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c5826bbd74832db4180724019afe74