### PR TITLE
docs: add rule references and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,14 @@ The project is structured as a Cargo workspace:
 The engine uses the [`patch`](https://crates.io/crates/patch) crate to parse diffs in the unified format. It understands
 standard text diffs, file renames, binary file changes, and multiple hunks within a single file.
 
+## Rule Reference
+
+- [secrets](docs/secrets.md)
+- [sql-injection-go](docs/sql_injection_go.md)
+- [http-timeouts-go](docs/http_timeouts_go.md)
+- [convention-deviation](docs/convention_deviation.md)
+- [server-xss-go](docs/server_xss_go.md)
+
 ## Contributing
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 

--- a/docs/convention_deviation.md
+++ b/docs/convention_deviation.md
@@ -1,0 +1,16 @@
+# convention-deviation
+
+Detects code that deviates from conventions inferred from the existing repository, such as using `println!` instead of logging macros, calling `.unwrap()` or `.expect()`, or defining functions that do not return `Result` when all others do.
+
+## Recommendation
+
+Follow established repository patterns: prefer logging macros over `println!`, use proper error handling instead of `.unwrap()` or `.expect()`, and align function signatures with prevailing `Result`-based style.
+
+## Configuration
+
+```toml
+[rules.convention-deviation]
+enabled = true
+severity = "medium"
+```
+

--- a/docs/http_timeouts_go.md
+++ b/docs/http_timeouts_go.md
@@ -1,0 +1,16 @@
+# http-timeouts-go
+
+Detects Go HTTP requests that omit timeouts, either by using the default client or a custom `http.Client` without a `Timeout` set.
+
+## Recommendation
+
+Always specify a timeout on HTTP clients or requests to avoid hanging connections.
+
+## Configuration
+
+```toml
+[rules.http-timeouts-go]
+enabled = true
+severity = "medium"
+```
+

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,16 @@
+# secrets
+
+Detects potential secrets and credentials committed to the repository, such as API keys, tokens, or private keys.
+
+## Recommendation
+
+Remove secrets from source control and store them in a dedicated secrets manager or environment variables. Rotate any exposed credentials.
+
+## Configuration
+
+```toml
+[rules.secrets]
+enabled = true
+severity = "medium"
+```
+

--- a/docs/sql_injection_go.md
+++ b/docs/sql_injection_go.md
@@ -1,0 +1,16 @@
+# sql-injection-go
+
+Detects dynamic SQL query construction in Go code that could lead to SQL injection vulnerabilities.
+
+## Recommendation
+
+Use parameterized queries or prepared statements with the `database/sql` package instead of string concatenation to build queries.
+
+## Configuration
+
+```toml
+[rules.sql-injection-go]
+enabled = true
+severity = "medium"
+```
+


### PR DESCRIPTION
## Summary
- add documentation for secrets, sql-injection-go, http-timeouts-go, and convention-deviation
- link rule docs from README rule reference section

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c5826b2798832db8d8e1e2b9302000