### PR TITLE
feat: surface suggested fixes in review reports

### DIFF
--- a/crates/engine/src/report/mod.rs
+++ b/crates/engine/src/report/mod.rs
@@ -54,17 +54,30 @@ impl ReportGenerator for MarkdownGenerator {
         if sorted_issues.is_empty() {
             md.push_str("✅ No issues found.\n");
         } else {
-            md.push_str("| Severity | Title | File:Line | Description |\n");
-            md.push_str("|---|---|---|---|\n");
+            md.push_str("| Severity | Title | File:Line | Description | Suggested Fix |\n");
+            md.push_str("|---|---|---|---|---|\n");
             for issue in &sorted_issues {
                 md.push_str(&format!(
-                    "| `{:?}` | {} | `{}:{}` | {} |\n",
+                    "| `{:?}` | {} | `{}:{}` | {} | {} |\n",
                     issue.severity,
                     issue.title,
                     issue.file_path,
                     issue.line_number,
-                    issue.description
+                    issue.description,
+                    issue
+                        .suggested_fix
+                        .clone()
+                        .unwrap_or_else(|| "-".to_string())
                 ));
+            }
+
+            for issue in &sorted_issues {
+                if let Some(diff) = &issue.diff {
+                    md.push_str(&format!(
+                        "\n<details>\n<summary>Diff suggestion for `{}` at `{}:{}`</summary>\n\n```diff\n{}\n```\n</details>\n",
+                        issue.title, issue.file_path, issue.line_number, diff
+                    ));
+                }
             }
         }
 

--- a/crates/engine/src/scanner/convention_deviation.rs
+++ b/crates/engine/src/scanner/convention_deviation.rs
@@ -101,6 +101,8 @@ impl Scanner for ConventionDeviationScanner {
                         file_path: file_path.to_string(),
                         line_number: i + 1,
                         severity: config.rules.convention_deviation.severity.clone(),
+                        suggested_fix: Some(pat.description.to_string()),
+                        diff: Some(format!("-{}\n+// {}", line.trim(), pat.description)),
                     });
                     matched = true;
                     break;
@@ -115,6 +117,14 @@ impl Scanner for ConventionDeviationScanner {
                         file_path: file_path.to_string(),
                         line_number: i + 1,
                         severity: config.rules.convention_deviation.severity.clone(),
+                        suggested_fix: Some(
+                            "Update function signature to return Result<T, E>".to_string(),
+                        ),
+                        diff: Some(format!(
+                            "-{}\n+{} -> Result<_, _>",
+                            line.trim(),
+                            line.trim()
+                        )),
                     });
                 }
             }

--- a/crates/engine/src/scanner/secrets.rs
+++ b/crates/engine/src/scanner/secrets.rs
@@ -43,6 +43,8 @@ impl Scanner for SecretsScanner {
                         file_path: file_path.to_string(),
                         line_number: i + 1,
                         severity: config.rules.secrets.severity.clone(),
+                        suggested_fix: Some("Remove secrets from source control and use secure storage or environment variables.".to_string()),
+                        diff: Some(format!("-{}\n+<redacted>", line.trim())),
                     });
                     // Don't flag the same line multiple times
                     break;

--- a/crates/engine/src/scanner/server_xss_go.rs
+++ b/crates/engine/src/scanner/server_xss_go.rs
@@ -31,6 +31,12 @@ impl Scanner for ServerXssGoScanner {
                     file_path: file_path.to_string(),
                     line_number: i + 1,
                     severity: config.rules.server_xss_go.severity.clone(),
+                    suggested_fix: Some("Use html/template which auto-escapes HTML.".to_string()),
+                    diff: Some(format!(
+                        "-{}\n+{}",
+                        line.trim(),
+                        line.replace("text/template", "html/template").trim()
+                    )),
                 });
             }
             if UNSAFE_WRITE_REGEX.is_match(line) {
@@ -42,6 +48,13 @@ impl Scanner for ServerXssGoScanner {
                     file_path: file_path.to_string(),
                     line_number: i + 1,
                     severity: config.rules.server_xss_go.severity.clone(),
+                    suggested_fix: Some(
+                        "Escape user input before writing to the response.".to_string(),
+                    ),
+                    diff: Some(format!(
+                        "-{}\n+// escape user input before writing",
+                        line.trim()
+                    )),
                 });
             }
         }

--- a/crates/engine/tests/report.rs
+++ b/crates/engine/tests/report.rs
@@ -28,6 +28,8 @@ fn markdown_generator_with_issues() {
         file_path: "lib.rs".into(),
         line_number: 42,
         severity: Severity::High,
+        suggested_fix: Some("Apply the recommended change".into()),
+        diff: Some("-old\n+new".into()),
     };
     let report = ReviewReport {
         summary: "Issues".into(),
@@ -40,6 +42,9 @@ fn markdown_generator_with_issues() {
     let md = generator.generate(&report).unwrap();
     assert!(md.contains("Test issue"));
     assert!(md.contains("lib.rs:42"));
+    assert!(md.contains("Apply the recommended change"));
+    assert!(md.contains("Diff suggestion for `Test issue` at `lib.rs:42`"));
+    assert!(md.contains("-old"));
     assert!(md.contains("Use snake_case for variables"));
     assert!(md.contains("src/main.rs:10 - complex function"));
     assert!(md.contains("```mermaid"));


### PR DESCRIPTION
## Summary
- extend `Issue` with `suggested_fix` and `diff`
- populate new fields across scanners
- render suggestions and diffs in markdown reports

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c582697028832d86a8e1fe63532254