### PR TITLE
Default generation temperature to zero

### DIFF
--- a/crates/engine/src/llm/mod.rs
+++ b/crates/engine/src/llm/mod.rs
@@ -64,7 +64,7 @@ pub fn create_llm_provider(config: &Config) -> Result<Box<dyn LlmProvider>> {
                 config.llm.model.clone().ok_or_else(|| {
                     EngineError::Config("Missing model for OpenAI provider".into())
                 })?;
-            let temperature = config.generation.temperature.unwrap_or(0.1);
+            let temperature = config.generation.temperature.unwrap_or(0.0);
             Ok(Box::new(openai::OpenAiProvider::new(
                 api_key,
                 model,
@@ -81,7 +81,7 @@ pub fn create_llm_provider(config: &Config) -> Result<Box<dyn LlmProvider>> {
             let model = config.llm.model.clone().ok_or_else(|| {
                 EngineError::Config("Missing model for Anthropic provider".into())
             })?;
-            let temperature = config.generation.temperature.unwrap_or(0.1);
+            let temperature = config.generation.temperature.unwrap_or(0.0);
             Ok(Box::new(anthropic::AnthropicProvider::new(
                 api_key,
                 model,
@@ -99,7 +99,7 @@ pub fn create_llm_provider(config: &Config) -> Result<Box<dyn LlmProvider>> {
                 config.llm.model.clone().ok_or_else(|| {
                     EngineError::Config("Missing model for DeepSeek provider".into())
                 })?;
-            let temperature = config.generation.temperature.unwrap_or(0.1);
+            let temperature = config.generation.temperature.unwrap_or(0.0);
             Ok(Box::new(deepseek::DeepSeekProvider::new(
                 api_key,
                 model,

--- a/docs/config.md
+++ b/docs/config.md
@@ -38,7 +38,7 @@ Optional sections let you cap token usage or adjust generation parameters:
 # max-per-run = 100000
 
 [generation]
-temperature = 0.2
+temperature = 0.0
 ```
 
 ## Using in CI

--- a/reviewer.toml.example
+++ b/reviewer.toml.example
@@ -44,7 +44,7 @@ provider = "null"
 # --- Generation Settings ---
 [generation]
 # Controls generation behaviour such as temperature.
-temperature = 0
+temperature = 0.0  # default for deterministic output
 
 
 # --- Privacy Settings ---


### PR DESCRIPTION
## Summary
- Use deterministic default temperature of 0.0 for all LLM providers
- Document the 0.0 generation temperature default

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c58861f0ec832d9c135affd4add1f4