### PR TITLE
Swap configuration and runtime error exit codes

### DIFF
--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -48,16 +48,16 @@ pub async fn run(args: CheckArgs, engine: &ReviewEngine) -> i32 {
                 match engine_error {
                     EngineError::Config(_) => {
                         log::error!("{}", e);
-                        3
+                        2
                     }
                     _ => {
                         log::error!("{}", e);
-                        2
+                        3
                     }
                 }
             } else {
                 log::error!("{}", e);
-                2
+                3
             }
         }
     }

--- a/crates/cli/tests/smoke.rs
+++ b/crates/cli/tests/smoke.rs
@@ -229,5 +229,5 @@ fn check_command_without_upstream_or_base_ref_errors() {
     let mut cmd = Command::cargo_bin("reviewer-cli").unwrap();
     cmd.args(["check", "--path", repo_str]);
 
-    cmd.assert().code(3);
+    cmd.assert().code(2);
 }

--- a/crates/engine/tests/exit_codes.rs
+++ b/crates/engine/tests/exit_codes.rs
@@ -1,0 +1,25 @@
+use engine::error::EngineError;
+
+fn map_error_to_exit_code(err: anyhow::Error) -> i32 {
+    if let Some(engine_error) = err.downcast_ref::<EngineError>() {
+        match engine_error {
+            EngineError::Config(_) => 2,
+            _ => 3,
+        }
+    } else {
+        3
+    }
+}
+
+#[test]
+fn config_error_returns_exit_code_two() {
+    let err: anyhow::Error = EngineError::Config("bad config".into()).into();
+    assert_eq!(map_error_to_exit_code(err), 2);
+}
+
+#[test]
+fn runtime_error_returns_exit_code_three() {
+    let io_err = std::io::Error::new(std::io::ErrorKind::Other, "io failure");
+    let err: anyhow::Error = EngineError::Io(io_err).into();
+    assert_eq!(map_error_to_exit_code(err), 3);
+}


### PR DESCRIPTION
## Summary
- swap exit codes: configuration/usage errors now exit with code 2 and runtime errors with 3
- update CLI tests for new exit code mapping
- add engine tests verifying exit code mapping logic

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c58d0117d0832da2d13fa41a5a8774