### PR TITLE
feat(engine): configurable hotspot risk weights

### DIFF
--- a/crates/engine/src/config.rs
+++ b/crates/engine/src/config.rs
@@ -25,6 +25,8 @@ pub struct Config {
     pub privacy: PrivacyConfig,
     #[serde(default)]
     pub paths: PathsConfig,
+    #[serde(default)]
+    pub report: ReportConfig,
     /// Optional path to a pre-built vector index used for RAG.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
@@ -164,6 +166,48 @@ fn default_include() -> Vec<String> {
     vec!["**/*".to_string()]
 }
 
+// As per PRD: `[report.hotspot_weights]` section
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub struct HotspotWeights {
+    #[serde(default = "default_severity_weight")]
+    pub severity: u32,
+    #[serde(default = "default_churn_weight")]
+    pub churn: u32,
+}
+
+impl Default for HotspotWeights {
+    fn default() -> Self {
+        Self {
+            severity: default_severity_weight(),
+            churn: default_churn_weight(),
+        }
+    }
+}
+
+fn default_severity_weight() -> u32 {
+    3
+}
+
+fn default_churn_weight() -> u32 {
+    1
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub struct ReportConfig {
+    #[serde(default)]
+    pub hotspot_weights: HotspotWeights,
+}
+
+impl Default for ReportConfig {
+    fn default() -> Self {
+        Self {
+            hotspot_weights: HotspotWeights::default(),
+        }
+    }
+}
+
 // As per PRD: `[rules]` section with severity
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, ValueEnum)]
 #[serde(rename_all = "kebab-case")]
@@ -246,6 +290,7 @@ impl Default for Config {
             generation: GenerationConfig::default(),
             privacy: PrivacyConfig::default(),
             paths: PathsConfig::default(),
+            report: ReportConfig::default(),
             index_path: Some(DEFAULT_INDEX_PATH.to_string()),
             rules: RulesConfig::default(),
             fail_on: default_fail_on(),

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -26,6 +26,7 @@ use crate::report::ReviewReport;
 use crate::scanner::Scanner;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use regex::Regex;
+use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
@@ -106,8 +107,8 @@ impl ReviewEngine {
             })
             .collect();
 
-        // Aggregate hotspots based on line churn.
-        let mut file_changes = Vec::new();
+        // Track line churn per file; hotspots are computed after scanning.
+        let mut churn_counts: HashMap<String, usize> = HashMap::new();
         for file in &filtered_files {
             let mut changes = 0usize;
             for hunk in &file.hunks {
@@ -120,15 +121,8 @@ impl ReviewEngine {
                     }
                 }
             }
-            file_changes.push((file.path.clone(), changes));
+            churn_counts.insert(file.path.clone(), changes);
         }
-        file_changes.sort_by(|a, b| b.1.cmp(&a.1));
-        let hotspots: Vec<String> = file_changes
-            .into_iter()
-            .filter(|(_, count)| *count > 0)
-            .take(5)
-            .map(|(path, count)| format!("{path} ({count} changes)"))
-            .collect();
 
         // 2. Run configured scanners on the filtered files, limiting results to diff hunks.
         let mut issues = Vec::new();
@@ -167,6 +161,29 @@ impl ReviewEngine {
                 }
             }
         }
+
+        // Aggregate hotspots using configurable severity and churn weights.
+        let mut issue_counts: HashMap<String, usize> = HashMap::new();
+        for issue in &issues {
+            *issue_counts.entry(issue.file_path.clone()).or_insert(0) += 1;
+        }
+        let sev_w = self.config.report.hotspot_weights.severity;
+        let churn_w = self.config.report.hotspot_weights.churn;
+        let mut file_risks: Vec<(String, u32)> = churn_counts
+            .into_iter()
+            .map(|(path, churn)| {
+                let findings = issue_counts.get(&path).copied().unwrap_or(0) as u32;
+                let risk = sev_w * findings + churn_w * (churn as u32);
+                (path, risk)
+            })
+            .collect();
+        file_risks.sort_by(|a, b| b.1.cmp(&a.1));
+        let hotspots: Vec<String> = file_risks
+            .into_iter()
+            .filter(|(_, risk)| *risk > 0)
+            .take(5)
+            .map(|(path, risk)| format!("{path} (risk {risk})"))
+            .collect();
 
         // 3. Retrieve RAG context for flagged regions.
         let vector_store: Box<dyn VectorStore + Send + Sync> =

--- a/docs/config.md
+++ b/docs/config.md
@@ -41,5 +41,14 @@ Optional sections let you cap token usage or adjust generation parameters:
 temperature = 0.0
 ```
 
+## Hotspot Weights
+Rank hotspots by combining scanner findings and code churn:
+```toml
+[report.hotspot_weights]
+severity = 3
+churn = 1
+```
+Higher `severity` favors files with more findings, while `churn` boosts files with more changed lines.
+
 ## Using in CI
 Supply sensitive values such as API keys via environment variables in your CI system. Example GitHub Actions and GitLab CI files live in [`docs/ci/`](ci/).

--- a/reviewer.toml.example
+++ b/reviewer.toml.example
@@ -55,6 +55,11 @@ enabled = true
 patterns = []
 
 
+# --- Report Settings ---
+[report.hotspot_weights]
+severity = 3  # weight for number of findings
+churn = 1     # weight for changed lines
+
 # --- Rule and Scanner Configuration ---
 [rules.secrets]
 enabled = true


### PR DESCRIPTION
## Summary
- make hotspot risk formula use configurable severity and churn weights
- expose `[report.hotspot_weights]` in config with defaults
- document hotspot weight defaults

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c58d021c9c832dbf35741093288912