### PR TITLE
Add flow-based mermaid diagrams

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -26,6 +26,7 @@ use crate::report::ReviewReport;
 use crate::scanner::Scanner;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use regex::Regex;
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 
@@ -133,9 +134,11 @@ impl ReviewEngine {
         // 2. Run configured scanners on the filtered files, limiting results to diff hunks.
         let mut issues = Vec::new();
         let mut code_quality = Vec::new();
-        for file in filtered_files {
+        let file_paths: Vec<String> = filtered_files.iter().map(|f| f.path.clone()).collect();
+        let mut interactions = HashSet::new();
+        for file in &filtered_files {
             let content = fs::read_to_string(&file.path)?;
-            let mut changed_lines = std::collections::HashSet::new();
+            let mut changed_lines = HashSet::new();
             for hunk in &file.hunks {
                 let mut new_line = hunk.new_start as usize;
                 for line in &hunk.lines {
@@ -166,9 +169,44 @@ impl ReviewEngine {
                     issues.append(&mut found);
                 }
             }
+
+            for other in &file_paths {
+                if other == &file.path {
+                    continue;
+                }
+                let stem = Path::new(other)
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("");
+                if content.contains(&format!("use {}", stem))
+                    || content.contains(&format!("{}::", stem))
+                {
+                    interactions.insert((file.path.clone(), other.clone()));
+                }
+            }
         }
 
-        // 3. Retrieve RAG context for flagged regions.
+        // 3. Perform lightweight flow extraction for sequence diagram.
+        let interactions: Vec<(String, String)> = interactions.into_iter().collect();
+        let mermaid_diagram = if interactions.len() >= 3 {
+            let mut diagram = String::from("sequenceDiagram\n");
+            for (from, to) in &interactions {
+                let from = Path::new(from)
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or(from);
+                let to = Path::new(to)
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or(to);
+                diagram.push_str(&format!("    {}->>{}: uses\n", from, to));
+            }
+            Some(diagram)
+        } else {
+            None
+        };
+
+        // 4. Retrieve RAG context for flagged regions.
         let vector_store: Box<dyn VectorStore + Send + Sync> =
             if let Some(path) = &self.config.index_path {
                 match InMemoryVectorStore::load_from_disk(path) {
@@ -195,7 +233,7 @@ impl ReviewEngine {
             }
         }
 
-        // 4. Call the selected LLM provider for suggestions.
+        // 5. Prepare the prompt for the LLM.
         let mut prompt = String::new();
         if !contexts.is_empty() {
             prompt.push_str("Context:\n");
@@ -207,7 +245,7 @@ impl ReviewEngine {
             issues
         ));
 
-        // 4. Redact issue descriptions and contexts before calling the LLM.
+        // 6. Redact issue descriptions and contexts before calling the LLM.
         let redacted_issues: Vec<String> = issues
             .iter()
             .map(|issue| {
@@ -228,7 +266,7 @@ impl ReviewEngine {
             redacted_contexts.join("\n")
         );
 
-        // 5. Call the selected LLM provider for suggestions.
+        // 7. Call the selected LLM provider for suggestions.
         if let Some(max) = self.config.budget.tokens.max_per_run {
             if total_tokens_used >= max {
                 return Err(EngineError::TokenBudgetExceeded {
@@ -248,13 +286,13 @@ impl ReviewEngine {
             }
         }
 
-        // 6. Build and return the ReviewReport.
+        // 8. Build and return the ReviewReport.
         let report = ReviewReport {
             summary: llm_response.content,
             issues,
             code_quality,
             hotspots,
-            mermaid_diagram: None,
+            mermaid_diagram,
             config: self.config.clone(),
         };
 

--- a/crates/engine/src/report/mod.rs
+++ b/crates/engine/src/report/mod.rs
@@ -14,7 +14,7 @@ pub struct ReviewReport {
     pub code_quality: Vec<String>,
     /// Paths or descriptions of files considered hotspots.
     pub hotspots: Vec<String>,
-    /// Optional Mermaid diagram describing flows or relationships.
+    /// Optional Mermaid sequence diagram showing file interactions.
     pub mermaid_diagram: Option<String>,
     pub config: Config,
 }

--- a/crates/engine/tests/sequence_diagram.rs
+++ b/crates/engine/tests/sequence_diagram.rs
@@ -1,0 +1,31 @@
+use engine::{config::Config, ReviewEngine};
+use std::fs;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn generates_sequence_diagram_when_files_interact() {
+    let dir = tempdir().unwrap();
+    let file_a = dir.path().join("a.rs");
+    let file_b = dir.path().join("b.rs");
+    let file_c = dir.path().join("c.rs");
+    fs::write(&file_a, "use crate::b; fn a() { b::b(); }\n").unwrap();
+    fs::write(&file_b, "use crate::c; fn b() { c::c(); }\n").unwrap();
+    fs::write(&file_c, "use crate::a; fn c() { a::a(); }\n").unwrap();
+
+    let diff = format!(
+        "diff --git a/{a} b/{a}\n--- a/{a}\n+++ b/{a}\n@@ -0,0 +1,1 @@\n+use crate::b; fn a() {{ b::b(); }}\n\
+diff --git a/{b} b/{b}\n--- a/{b}\n+++ b/{b}\n@@ -0,0 +1,1 @@\n+use crate::c; fn b() {{ c::c(); }}\n\
+diff --git a/{c} b/{c}\n--- a/{c}\n+++ b/{c}\n@@ -0,0 +1,1 @@\n+use crate::a; fn c() {{ a::a(); }}\n",
+        a = file_a.to_str().unwrap(),
+        b = file_b.to_str().unwrap(),
+        c = file_c.to_str().unwrap()
+    );
+
+    let engine = ReviewEngine::new(Config::default()).unwrap();
+    let report = engine.run(&diff).await.unwrap();
+    let diagram = report.mermaid_diagram.expect("expected diagram");
+    assert!(diagram.contains("sequenceDiagram"));
+    assert!(diagram.contains("a.rs->>b.rs"));
+    assert!(diagram.contains("b.rs->>c.rs"));
+    assert!(diagram.contains("c.rs->>a.rs"));
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -41,5 +41,8 @@ Optional sections let you cap token usage or adjust generation parameters:
 temperature = 0.0
 ```
 
+## Diagrams
+When three or more changed files reference one another, the engine populates `mermaid_diagram` in the `ReviewReport` with a simple Mermaid sequence diagram. The Markdown report renders this automatically; no additional configuration is required.
+
 ## Using in CI
 Supply sensitive values such as API keys via environment variables in your CI system. Example GitHub Actions and GitLab CI files live in [`docs/ci/`](ci/).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -24,6 +24,8 @@ reviewer-cli check --base-ref main
 ```
 The CLI prints a short summary and the top hotspots to stdout, while the full report is written to `review_report.md`.
 
+When three or more files reference one another, the report also includes a Mermaid sequence diagram visualizing the flow between them.
+
 ## CI Setup
 The CLI can gate pull requests by exiting non‑zero when issues are found. See the sample configurations in [`docs/ci/`](ci/) for GitHub Actions and GitLab CI examples.
 


### PR DESCRIPTION
## Summary
- derive file interaction flows to render Mermaid sequence diagrams when three or more files reference one another
- document automatic diagram generation in quickstart and config docs

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c58d0291b8832db9aa59808b062156