### PR TITLE
feat(config): add index table

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2,7 +2,7 @@
 
 use clap::Parser;
 use engine::{
-    config::{Config, Provider},
+    config::{Config, IndexConfig, Provider},
     ReviewEngine,
 };
 use env_logger::Target;
@@ -144,7 +144,7 @@ async fn main() -> anyhow::Result<()> {
         config.llm.base_url = Some(url);
     }
     if let Some(path) = cli.index_path {
-        config.index_path = Some(path);
+        config.index = Some(IndexConfig { path });
     }
     if let Some(max) = cli.budget_tokens_max_per_run {
         config.budget.tokens.max_per_run = Some(max);

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -170,7 +170,7 @@ impl ReviewEngine {
 
         // 3. Retrieve RAG context for flagged regions.
         let vector_store: Box<dyn VectorStore + Send + Sync> =
-            if let Some(path) = &self.config.index_path {
+            if let Some(path) = self.config.index_path() {
                 match InMemoryVectorStore::load_from_disk(path) {
                     Ok(store) => Box::new(store),
                     Err(e) => {

--- a/crates/engine/src/scanner/convention_deviation.rs
+++ b/crates/engine/src/scanner/convention_deviation.rs
@@ -77,7 +77,7 @@ impl Scanner for ConventionDeviationScanner {
 
     fn scan(&self, file_path: &str, content: &str, config: &Config) -> Result<Vec<Issue>> {
         let mut issues = Vec::new();
-        let index_path = match &config.index_path {
+        let index_path = match config.index_path() {
             Some(p) => p,
             None => return Ok(issues),
         };

--- a/crates/engine/tests/code_quality_hotspots.rs
+++ b/crates/engine/tests/code_quality_hotspots.rs
@@ -1,5 +1,5 @@
 use engine::{
-    config::Config,
+    config::{Config, IndexConfig},
     report::{MarkdownGenerator, ReportGenerator},
     ReviewEngine,
 };
@@ -34,7 +34,9 @@ async fn run_populates_code_quality_and_hotspots() {
 
     let index = build_index(&[("existing.rs", "fn existing() { log::info!(\"hi\"); }")]);
     let mut config = Config::default();
-    config.index_path = Some(index.path().to_str().unwrap().to_string());
+    config.index = Some(IndexConfig {
+        path: index.path().to_str().unwrap().to_string(),
+    });
 
     let engine = ReviewEngine::new(config).unwrap();
     let report = engine.run(&diff).await.unwrap();

--- a/crates/engine/tests/convention_deviation.rs
+++ b/crates/engine/tests/convention_deviation.rs
@@ -1,4 +1,4 @@
-use engine::config::Config;
+use engine::config::{Config, IndexConfig};
 use engine::scanner::{ConventionDeviationScanner, Scanner};
 use regex::Regex;
 use serde_json::json;
@@ -59,7 +59,9 @@ fn build_index(docs: &[(&str, &str)]) -> NamedTempFile {
 fn detects_println_usage() {
     let index = build_index(&[("existing.rs", "fn existing() { log::info!(\"hi\"); }")]);
     let mut config = Config::default();
-    config.index_path = Some(index.path().to_str().unwrap().to_string());
+    config.index = Some(IndexConfig {
+        path: index.path().to_str().unwrap().to_string(),
+    });
     let scanner = ConventionDeviationScanner;
     let content = "fn new() { println!(\"hi\"); }";
     let issues = scanner
@@ -73,7 +75,9 @@ fn detects_println_usage() {
 fn detects_unwrap_usage() {
     let index = build_index(&[("existing.rs", "fn existing() -> Result<(), anyhow::Error> { Ok(()) }")]);
     let mut config = Config::default();
-    config.index_path = Some(index.path().to_str().unwrap().to_string());
+    config.index = Some(IndexConfig {
+        path: index.path().to_str().unwrap().to_string(),
+    });
     let scanner = ConventionDeviationScanner;
     let content = "fn new() { let x = option.unwrap(); }";
     let issues = scanner
@@ -87,7 +91,9 @@ fn detects_unwrap_usage() {
 fn allows_log_usage() {
     let index = build_index(&[("existing.rs", "fn existing() { log::info!(\"hi\"); }")]);
     let mut config = Config::default();
-    config.index_path = Some(index.path().to_str().unwrap().to_string());
+    config.index = Some(IndexConfig {
+        path: index.path().to_str().unwrap().to_string(),
+    });
     let scanner = ConventionDeviationScanner;
     let content = "fn new() { log::warn!(\"hi\"); }";
     let issues = scanner
@@ -100,7 +106,9 @@ fn allows_log_usage() {
 fn detects_eprintln_usage() {
     let index = build_index(&[("existing.rs", "fn existing() { log::info!(\"hi\"); }")]);
     let mut config = Config::default();
-    config.index_path = Some(index.path().to_str().unwrap().to_string());
+    config.index = Some(IndexConfig {
+        path: index.path().to_str().unwrap().to_string(),
+    });
     let scanner = ConventionDeviationScanner;
     let content = "fn new() { eprintln!(\"hi\"); }";
     let issues = scanner
@@ -114,7 +122,9 @@ fn detects_eprintln_usage() {
 fn detects_expect_usage() {
     let index = build_index(&[("existing.rs", "fn existing() -> Result<(), anyhow::Error> { Ok(()) }")]);
     let mut config = Config::default();
-    config.index_path = Some(index.path().to_str().unwrap().to_string());
+    config.index = Some(IndexConfig {
+        path: index.path().to_str().unwrap().to_string(),
+    });
     let scanner = ConventionDeviationScanner;
     let content = "fn new() { let x = option.expect(\"hi\"); }";
     let issues = scanner
@@ -128,7 +138,9 @@ fn detects_expect_usage() {
 fn detects_missing_result_return() {
     let index = build_index(&[("existing.rs", "fn existing() -> Result<(), anyhow::Error> { Ok(()) }")]);
     let mut config = Config::default();
-    config.index_path = Some(index.path().to_str().unwrap().to_string());
+    config.index = Some(IndexConfig {
+        path: index.path().to_str().unwrap().to_string(),
+    });
     let scanner = ConventionDeviationScanner;
     let content = "fn new() { do_something(); }";
     let issues = scanner

--- a/crates/engine/tests/diff_hunk.rs
+++ b/crates/engine/tests/diff_hunk.rs
@@ -1,4 +1,4 @@
-use engine::{config::Config, ReviewEngine};
+use engine::{config::{Config, IndexConfig}, ReviewEngine};
 use serde_json::json;
 use std::fs;
 use std::io::Write;
@@ -34,7 +34,9 @@ async fn only_reports_issues_on_changed_lines() {
 
     let index = build_index(&[("existing.rs", "fn existing() { log::info!(\"hi\"); }")]);
     let mut config = Config::default();
-    config.index_path = Some(index.path().to_str().unwrap().to_string());
+    config.index = Some(IndexConfig {
+        path: index.path().to_str().unwrap().to_string(),
+    });
 
     let engine = ReviewEngine::new(config).unwrap();
     let report = engine.run(&diff).await.unwrap();

--- a/docs/config.md
+++ b/docs/config.md
@@ -14,6 +14,17 @@ deny  = ["target/*", "**/testdata/*"]
 ```
 Only files in `paths.allow` are indexed, helping enforce repository boundaries.
 
+## Index
+
+Override the location of the pre-built vector index:
+
+```toml
+[index]
+path = ".reviewer/index/index.json"
+```
+
+The older top-level `index-path` setting is deprecated.
+
 ## LLM Provider
 ```toml
 [llm]

--- a/fixtures/clean/reviewer.toml
+++ b/fixtures/clean/reviewer.toml
@@ -1,4 +1,5 @@
-index-path = "index.json"
+[index]
+path = "index.json"
 
 [paths]
 allow = ["**/*"]

--- a/fixtures/http-timeout/reviewer.toml
+++ b/fixtures/http-timeout/reviewer.toml
@@ -1,4 +1,5 @@
-index-path = "index.json"
+[index]
+path = "index.json"
 
 [paths]
 allow = ["**/*"]

--- a/fixtures/secrets/reviewer.toml
+++ b/fixtures/secrets/reviewer.toml
@@ -1,4 +1,5 @@
-index-path = "index.json"
+[index]
+path = "index.json"
 
 [paths]
 allow = ["**/*"]

--- a/fixtures/server-xss/reviewer.toml
+++ b/fixtures/server-xss/reviewer.toml
@@ -1,4 +1,5 @@
-index-path = "index.json"
+[index]
+path = "index.json"
 
 [paths]
 allow = ["**/*"]

--- a/fixtures/sql-injection/reviewer.toml
+++ b/fixtures/sql-injection/reviewer.toml
@@ -1,4 +1,5 @@
-index-path = "index.json"
+[index]
+path = "index.json"
 
 [paths]
 allow = ["**/*"]

--- a/reviewer.toml
+++ b/reviewer.toml
@@ -2,9 +2,10 @@
 # Copy this file to `reviewer.toml` and customize it for your project.
 
 # --- Paths Configuration ---
-# Optional path to a pre-built vector index for Retrieval-Augmented Generation.
-# If provided, the engine will load this index at startup.
-index-path = ".reviewer/index/index.json"
+# Optional configuration for a pre-built vector index used for
+# Retrieval-Augmented Generation.
+[index]
+path = ".reviewer/index/index.json"
 
 [paths]
 # Paths to include (allow) in the analysis. Globs are supported.

--- a/reviewer.toml.example
+++ b/reviewer.toml.example
@@ -4,9 +4,10 @@
 # and by CLI flags. Precedence: CLI flags > env vars > this file.
 
 # --- Paths Configuration ---
-# Optional path to a pre-built vector index for Retrieval-Augmented Generation.
-# If provided, the engine will load this index at startup.
-index-path = ".reviewer/index/index.json"
+# Optional configuration for a pre-built vector index used for
+# Retrieval-Augmented Generation.
+[index]
+path = ".reviewer/index/index.json"
 
 # Minimum issue severity that triggers a non-zero exit code.
 # Defaults to "low" if omitted.


### PR DESCRIPTION
## Summary
- add `[index]` table with `IndexConfig` and deprecate top-level `index_path`
- update CLI and docs to use the new table
- migrate example configs and fixtures

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c58d03d774832d9962ce1a88bdc0e0