### PR TITLE
feat(report): capture runtime metadata

### DIFF
--- a/crates/engine/tests/report.rs
+++ b/crates/engine/tests/report.rs
@@ -1,5 +1,7 @@
 use engine::config::{Config, Severity};
-use engine::report::{MarkdownGenerator, ReportGenerator, ReviewReport};
+use engine::report::{
+    MarkdownGenerator, ReportGenerator, ReviewReport, RuntimeMetadata, TimingInfo,
+};
 use engine::scanner::Issue;
 
 #[test]
@@ -12,11 +14,19 @@ fn markdown_generator_no_issues() {
         hotspots: vec![],
         mermaid_diagram: None,
         config: Config::default(),
+        metadata: RuntimeMetadata {
+            ruleset_version: "v1".into(),
+            model: Some("test-model".into()),
+            driver: "null".into(),
+            timings: TimingInfo { total_ms: 0 },
+            index_warm: true,
+        },
     };
     let md = generator.generate(&report).unwrap();
     assert!(md.contains("✅ No issues found."));
     assert!(md.contains("No code quality issues found."));
     assert!(md.contains("No hotspots identified."));
+    assert!(md.contains("\"ruleset_version\": \"v1\""));
 }
 
 #[test]
@@ -38,6 +48,13 @@ fn markdown_generator_with_issues() {
         hotspots: vec!["src/main.rs:10 - complex function".into()],
         mermaid_diagram: Some("graph TD;A-->B;".into()),
         config: Config::default(),
+        metadata: RuntimeMetadata {
+            ruleset_version: "v1".into(),
+            model: Some("test-model".into()),
+            driver: "null".into(),
+            timings: TimingInfo { total_ms: 0 },
+            index_warm: false,
+        },
     };
     let md = generator.generate(&report).unwrap();
     assert!(md.contains("Test issue"));
@@ -49,4 +66,5 @@ fn markdown_generator_with_issues() {
     assert!(md.contains("src/main.rs:10 - complex function"));
     assert!(md.contains("```mermaid"));
     assert!(md.contains("A-->B"));
+    assert!(md.contains("\"driver\": \"null\""));
 }


### PR DESCRIPTION
## Summary
- track run metadata including ruleset version, model and driver identifiers, run duration, and warm/cold index
- render runtime metadata in Markdown report appendix
- exercise metadata output in report generator tests

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c58d0494c4832d88bd13e63a494487