### PR TITLE
ci: add security and license checks to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,18 @@ jobs:
           toolchain: stable
           target: ${{ matrix.target }}
 
+      - name: Install cargo-audit and cargo-deny
+        run: |
+          cargo install --locked cargo-audit cargo-deny
+
       - name: Build binary
         run: cargo build --release --bin reviewer-cli --target ${{ matrix.target }}
+
+      - name: Run cargo audit
+        run: cargo audit
+
+      - name: Run cargo deny
+        run: cargo deny check licenses
 
       - name: Package binary
         id: package


### PR DESCRIPTION
## Summary
- run `cargo audit` and `cargo deny` before packaging binaries
- ensure release fails on detected vulnerabilities or license issues

## Testing
- `cargo audit`
- `cargo deny check licenses` *(fails: license is not explicitly allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68c58d071b24832d8324358e09186300