### PR TITLE
docs: fix repo references and CLI name

### DIFF
--- a/PRD_v1.0.0.md
+++ b/PRD_v1.0.0.md
@@ -75,7 +75,7 @@ Code review has become a bottleneck. Large, AI-generated PRs overwhelm human rev
 
 ### In Scope
 
-* **CLI**: `reviewer check --path . --diff <ref>` (local & CI).
+* **CLI**: `reviewlens check --path . --diff <ref>` (local & CI).
 
   * `--diff` defaults to upstream base (auto-detected); override with `--base-ref <ref>`.
 * **Outputs**: `review_report.md` + stdout summary; CI-friendly exit codes.
@@ -104,7 +104,7 @@ Code review has become a bottleneck. Large, AI-generated PRs overwhelm human rev
 
 **A1. Install & Help**
 *As a developer, I can install the CLI and see commands.*
-**AC**: `reviewer --help` lists `check`, `index`, `print-config`, `version`.
+**AC**: `reviewlens --help` lists `check`, `index`, `print-config`, `version`.
 
 **A2. Config**
 *As a developer, I can configure models, budgets, and path filters.*
@@ -171,7 +171,7 @@ Code review has become a bottleneck. Large, AI-generated PRs overwhelm human rev
 
 ### Components
 
-* **CLI (`reviewer`)** — args parsing, config loading, orchestrates a review run.
+* **CLI (`reviewlens`)** — args parsing, config loading, orchestrates a review run.
 * **Engine (library)** — diff ingestion → rules → (optional) LLM → report.
 * **Ruleset (rules-go)** — SAST-lite checks for Go + generic patterns.
 * **RAG-lite Indexer** — local symbol/pattern index from base branch.
@@ -343,7 +343,7 @@ path = ".reviewer/index"
 **DX/Distribution**
 
 * Signed release artifacts + checksums; Homebrew tap; Docker image.
-* `reviewer --help` accurate; `print-config` shows effective config + compiled-in providers.
+* `reviewlens --help` accurate; `print-config` shows effective config + compiled-in providers.
 
 **Docs/Policy**
 
@@ -364,10 +364,10 @@ path = ".reviewer/index"
 
 ### B. Commands (CLI)
 
-* `reviewer check [--path PATH] [--diff REF] [--base-ref REF] [--fail-on {critical,high,medium,low}]`
-* `reviewer index [--path PATH]`
-* `reviewer print-config`
-* `reviewer version`
+* `reviewlens check [--path PATH] [--diff REF] [--base-ref REF] [--fail-on {critical,high,medium,low}]`
+* `reviewlens index [--path PATH]`
+* `reviewlens print-config`
+* `reviewlens version`
 
 ### C. Definitions
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ cargo install reviewlens
 For a containerized environment, pull the pre-built image from GitHub's container registry.
 
 ```bash
-docker pull ghcr.io/some-org/reviewlens:latest
-docker run --rm -v "$(pwd):/work" ghcr.io/some-org/reviewlens:latest check --base-ref main
+docker pull ghcr.io/Review-LensAi/reviewlens:latest
+docker run --rm -v "$(pwd):/work" ghcr.io/Review-LensAi/reviewlens:latest check --base-ref main
 ```
 
 You can also build the image locally:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,7 +5,7 @@ This guide helps you install and run the `reviewlens` locally or in CI.
 ## Installation
 - Use the install script:
   ```bash
-  curl -fsSL https://raw.githubusercontent.com/some-org/intelligent-code-reviewer/main/install.sh | sh
+  curl -fsSL https://raw.githubusercontent.com/Review-LensAi/reviewlens/main/install.sh | sh
   ```
 - Download a release binary and place it in your `PATH`.
 - Or build from source with `cargo install`.
@@ -20,7 +20,7 @@ This guide helps you install and run the `reviewlens` locally or in CI.
 ## Inspect Effective Configuration
 After configuring, you can inspect the merged settings, compiled providers, and the detected base reference:
 ```bash
-reviewer-cli print-config
+reviewlens print-config
 ```
 Look for the `Base ref:` line in the output to see which upstream branch will be used for diffs.
 

--- a/project-summary.md
+++ b/project-summary.md
@@ -14,7 +14,7 @@ Prompt & tool schema versioning: versioned prompts/templates, function-calling/t
 Offline/air-gapped mode: allow pure static analysis + optional local model usage (no code leaves the machine).
 Cost/latency controls: max tokens, temperature, retries, circuit breakers, and per-provider budgets.
 What We’re Building First (CLI-First MVP)
-CLI command: reviewer check --path . --diff main
+CLI command: reviewlens check --path . --diff main
 Outputs:
 review_report.md (summary, risks, suggested fixes, Mermaid diagrams)
 Exit codes for CI gating (0 clean, 1 issues)


### PR DESCRIPTION
## Summary
- point quickstart to Review-LensAi/reviewlens install script and CLI name
- update README Docker image to ghcr.io/Review-LensAi/reviewlens
- replace remaining legacy `reviewer` command references in docs

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c65578b7d0832d8e46f727ecedd38e