### PR TITLE
docs: update security contact

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -37,7 +37,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at security@example.com. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at security@reviewlens.dev. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@ We take security seriously and appreciate your efforts to responsibly disclose v
 
 ## Reporting a Vulnerability
 
-If you discover a security issue, please email security@example.com with a detailed report.
+If you discover a security issue, please email security@reviewlens.dev with a detailed report.
 
-We will acknowledge your email within 72 hours and work with you on a coordinated disclosure.
+This inbox is actively monitored by the security team, and we will acknowledge your email within 72 hours and work with you on a coordinated disclosure.
 
 Please do not disclose the issue publicly until we have had an opportunity to address it.


### PR DESCRIPTION
## Summary
- replace placeholder security email with security@reviewlens.dev
- note that the security inbox is actively monitored

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c65581a36c832d9e53eadf06310f4e