### PR TITLE
chore: rename homebrew formula and add checksum updater

### DIFF
--- a/homebrew-tap/reviewlens.rb
+++ b/homebrew-tap/reviewlens.rb
@@ -28,6 +28,6 @@ class ReviewLens < Formula
   end
 
   test do
-    system "\#{bin}/reviewlens", "--help"
+    assert_match version.to_s, shell_output("\#{bin}/reviewlens --version")
   end
 end

--- a/scripts/update-homebrew-formula.py
+++ b/scripts/update-homebrew-formula.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import sys
+import pathlib
+import subprocess
+import urllib.request
+
+if len(sys.argv) != 2:
+    print(f"Usage: {sys.argv[0]} <version>", file=sys.stderr)
+    sys.exit(1)
+
+version = sys.argv[1]
+repo = "Review-LensAi/reviewlens"
+formula = pathlib.Path(__file__).resolve().parent.parent / "homebrew-tap" / "reviewlens.rb"
+
+targets = {
+    "ARM64_MAC_SHA256": "aarch64-apple-darwin",
+    "X86_64_MAC_SHA256": "x86_64-apple-darwin",
+    "ARM64_LINUX_SHA256": "aarch64-unknown-linux-gnu",
+    "X86_64_LINUX_SHA256": "x86_64-unknown-linux-gnu",
+}
+
+checksums = {}
+for key, target in targets.items():
+    url = f"https://github.com/{repo}/releases/download/v{version}/reviewlens-{target}.tar.gz.sha256"
+    with urllib.request.urlopen(url) as resp:
+        checksums[key] = resp.read().decode().split()[0]
+
+content = formula.read_text()
+content = content.replace('version "1.0.0"', f'version "{version}"')
+for key, checksum in checksums.items():
+    content = content.replace(f"<{key}>", checksum)
+formula.write_text(content)
+
+# verify installation if Homebrew is available
+if subprocess.call(["which", "brew"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) == 0:
+    subprocess.check_call(["brew", "install", "--formula", str(formula)])
+    subprocess.check_call(["reviewlens", "--version"])
+else:
+    print("Homebrew not found; skipping install verification.", file=sys.stderr)


### PR DESCRIPTION
## Summary
- rename `reviewer-cli.rb` to canonical `reviewlens.rb`
- add script to populate Homebrew formula checksums and optionally verify installation
- ensure formula test checks installed binary version

## Testing
- `cargo test`
- `scripts/update-homebrew-formula.py 1.0.0` *(fails: HTTP Error 404: Not Found)*

------
https://chatgpt.com/codex/tasks/task_e_68c65588ea8c832da0518e510cd8d47d