### PR TITLE
Add default redaction patterns and document overrides

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -38,9 +38,18 @@ Set `provider` and `api_key` to use a remote model. The default `provider = "nul
 ```toml
 [privacy.redaction]
 enabled = true
-patterns = []
+patterns = ["aws_secret", "api_key", "token="]
 ```
-Secret redaction is enabled by default, and additional patterns can be supplied. Combine this with path allowlists to ensure code privacy.
+Secret redaction is enabled by default and ships with patterns for AWS secrets, API keys, and token parameters.
+Extend the list by appending additional regular expressions:
+
+```toml
+[privacy.redaction]
+patterns = ["aws_secret", "api_key", "token=", "passphrase"]
+```
+
+Override the defaults entirely with the `REVIEWLENS_PRIVACY_REDACTION_PATTERNS` environment variable or the
+`--privacy-redaction-patterns` CLI flag (comma separated). Combine this with path allowlists to ensure code privacy.
 
 ## Budget and Generation
 Optional sections let you cap token usage or adjust generation parameters:

--- a/reviewlens.toml.example
+++ b/reviewlens.toml.example
@@ -53,7 +53,7 @@ temperature = 0.0  # default for deterministic output
 # Enable redaction of sensitive content from prompts and logs.
 enabled = true
 # Regular expression patterns to redact.
-patterns = []
+patterns = ["aws_secret", "api_key", "token="]
 
 
 # --- Report Settings ---


### PR DESCRIPTION
## Summary
- Add default redaction patterns for common secrets
- Explain how to extend or override patterns in config

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c659335d48832d9532ad68910537d9