### PR TITLE
Enhance evaluation script with security metrics and memory profiling

### DIFF
--- a/scripts/eval.sh
+++ b/scripts/eval.sh
@@ -6,7 +6,8 @@ expected=(1 1 1 1 0)
 
 total_tp=0
 total_fp=0
-total_time=0
+runtimes=()
+memories=()
 
 for i in "${!fixtures[@]}"; do
   name=${fixtures[$i]}
@@ -15,7 +16,9 @@ for i in "${!fixtures[@]}"; do
 
   rm -rf "$dir/.git" "$dir/index.json" "$dir/review_report.md"
 
-  cargo run --quiet -p reviewlens -- --config "$dir/reviewlens.toml" index --path "$dir" --output "$dir/index.json" >/dev/null
+  /usr/bin/time -f "%M" -o /tmp/mem.txt \
+    cargo run --quiet -p reviewlens -- --config "$dir/reviewlens.toml" index \
+    --path "$dir" --output "$dir/index.json" >/dev/null 2>&1
 
   git -C "$dir" init -q
   git -C "$dir" commit -qm init --allow-empty
@@ -23,30 +26,68 @@ for i in "${!fixtures[@]}"; do
   git -C "$dir" reset index.json reviewlens.toml 2>/dev/null || true
 
   start=$(date +%s%N)
-  cargo run --quiet -p reviewlens -- --config "$dir/reviewlens.toml" check --path "$dir" --diff HEAD --output "$dir/review_report.md" >/dev/null
+  /usr/bin/time -f "%M" -o /tmp/mem.txt \
+    cargo run --quiet -p reviewlens -- --config "$dir/reviewlens.toml" check \
+    --path "$dir" --diff HEAD --output "$dir/review_report.md" >/dev/null 2>&1 || true
   end=$(date +%s%N)
   runtime=$(( (end-start)/1000000 ))
-  total_time=$(( total_time + runtime ))
+  memory=$(tail -n 1 /tmp/mem.txt)
+  runtimes+=("$runtime")
+  memories+=("$memory")
 
-  count=$(rg -c '^\| ' "$dir/review_report.md" 2>/dev/null || echo 0)
-  if [ "$count" -gt 0 ]; then
-    findings=$((count - 1))
-  else
+  security_section=$(awk '/^## .*Security Findings/{flag=1;next}/^## /{flag=0}flag' "$dir/review_report.md")
+  if echo "$security_section" | rg -q 'No issues found'; then
     findings=0
+  else
+    count=$(echo "$security_section" | rg -c '^\| ' || true)
+    findings=$(( count > 0 ? count - 1 : 0 ))
   fi
+
   tp=$(( findings < exp ? findings : exp ))
   fp=$(( findings > exp ? findings - exp : 0 ))
   total_tp=$(( total_tp + tp ))
   total_fp=$(( total_fp + fp ))
 
-  echo "$name: runtime=${runtime}ms findings=$findings expected=$exp"
+  echo "$name: runtime=${runtime}ms memory=${memory}KB findings=$findings expected=$exp"
 done
+
+sorted_runtime=($(printf '%s\n' "${runtimes[@]}" | sort -n))
+sorted_memory=($(printf '%s\n' "${memories[@]}" | sort -n))
+count=${#sorted_runtime[@]}
+mid=$(((count-1)/2))
+p95_idx=$((95*(count-1)/100))
+p50_runtime=${sorted_runtime[$mid]}
+p95_runtime=${sorted_runtime[$p95_idx]}
+p50_memory=${sorted_memory[$mid]}
+p95_memory=${sorted_memory[$p95_idx]}
 
 if [ $((total_tp + total_fp)) -gt 0 ]; then
   precision=$(awk "BEGIN {printf \"%.2f\", $total_tp/($total_tp+$total_fp)}")
+  fp_rate=$(awk "BEGIN {printf \"%.2f\", $total_fp/($total_tp+$total_fp)}")
 else
   precision="0.00"
+  fp_rate="0.00"
 fi
 
-echo "Total runtime: ${total_time}ms"
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "### Evaluation Summary"
+    echo ""
+    echo "| Metric | Value |"
+    echo "| --- | --- |"
+    echo "| Precision | $precision |"
+    echo "| FP Rate | $fp_rate |"
+    echo "| Runtime P50 (ms) | $p50_runtime |"
+    echo "| Runtime P95 (ms) | $p95_runtime |"
+    echo "| Memory P50 (KB) | $p50_memory |"
+    echo "| Memory P95 (KB) | $p95_memory |"
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
 echo "Precision: $precision"
+echo "FP Rate: $fp_rate"
+echo "Runtime P50: ${p50_runtime}ms"
+echo "Runtime P95: ${p95_runtime}ms"
+echo "Memory P50: ${p50_memory}KB"
+echo "Memory P95: ${p95_memory}KB"
+


### PR DESCRIPTION
## Summary
- parse and count security findings explicitly in evaluation
- wrap `cargo run` with `/usr/bin/time` to record memory usage
- report runtime P50/P95, memory P50/P95, precision, and FP rate to step summary

## Testing
- `bash scripts/eval.sh`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c65c59cfc0832dbe943b0c592232ba