### PR TITLE
Load index via accessor in engine run

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -259,7 +259,7 @@ impl ReviewEngine {
 
         // 3. Retrieve RAG context for flagged regions.
         let (vector_store, index_warm): (Box<dyn VectorStore + Send + Sync>, bool) =
-            if let Some(path) = &self.config.index_path {
+            if let Some(path) = self.config.index_path() {
                 match InMemoryVectorStore::load_from_disk(path) {
                     Ok(store) => (Box::new(store), true),
                     Err(e) => {

--- a/crates/engine/tests/index_table.rs
+++ b/crates/engine/tests/index_table.rs
@@ -1,0 +1,43 @@
+use engine::{
+    config::{Config, IndexConfig},
+    ReviewEngine,
+};
+use serde_json::json;
+use std::fs;
+use std::io::Write;
+use tempfile::{tempdir, NamedTempFile};
+
+fn build_index(docs: &[(&str, &str)]) -> NamedTempFile {
+    let mut file = NamedTempFile::new().expect("create temp index");
+    let documents: Vec<_> = docs
+        .iter()
+        .map(|(f, c)| json!({"filename": f, "content": c}))
+        .collect();
+    let data = json!({"documents": documents});
+    file.write_all(data.to_string().as_bytes())
+        .expect("write index");
+    file.flush().expect("flush index");
+    file
+}
+
+#[tokio::test]
+async fn loads_index_from_index_table() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("lib.rs");
+    fs::write(&file_path, "fn main() {\n}").unwrap();
+    let path_str = file_path.to_str().unwrap();
+    let diff = format!(
+        "diff --git a/{p} b/{p}\n--- a/{p}\n+++ b/{p}\n@@ -0,0 +1 @@\n+fn main() {{}}\n",
+        p = path_str
+    );
+
+    let index = build_index(&[("existing.rs", "fn existing() { log::info!(\\\"hi\\\"); }")]);
+    let mut config = Config::default();
+    config.index = Some(IndexConfig {
+        path: index.path().to_str().unwrap().to_string(),
+    });
+
+    let engine = ReviewEngine::new(config).unwrap();
+    let report = engine.run(&diff).await.unwrap();
+    assert!(report.metadata.index_warm);
+}


### PR DESCRIPTION
## Summary
- Use `Config::index_path()` in engine run to support `[index]` table
- Test that configs using `[index]` load the index

## Testing
- `cargo test -p engine`


------
https://chatgpt.com/codex/tasks/task_e_68c663410c90832d9b578c5a800c9731