### PR TITLE
feat(cli): add path option to print-config

### DIFF
--- a/crates/cli/src/commands/print_config.rs
+++ b/crates/cli/src/commands/print_config.rs
@@ -12,6 +12,10 @@ pub struct PrintConfigArgs {
     /// If not provided, the upstream of the current branch is used.
     #[arg(long, alias = "diff")]
     pub base_ref: Option<String>,
+
+    /// The path to the repository to inspect.
+    #[arg(long, default_value = ".")]
+    pub path: String,
 }
 
 /// Executes the `print-config` subcommand.
@@ -25,7 +29,14 @@ pub fn run(args: PrintConfigArgs, config: &Config) -> anyhow::Result<()> {
         base
     } else {
         let upstream_output = Command::new("git")
-            .args(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"])
+            .args([
+                "-C",
+                &args.path,
+                "rev-parse",
+                "--abbrev-ref",
+                "--symbolic-full-name",
+                "@{u}",
+            ])
             .output()
             .map_err(|e| anyhow::anyhow!("failed to detect upstream base: {}", e))?;
         if !upstream_output.status.success() {

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,9 +18,10 @@ This guide helps you install and run the `reviewlens` locally or in CI.
 2. Set your LLM provider and API key. Configuration values can also be supplied via environment variables or CLI flags.
 
 ## Inspect Effective Configuration
-After configuring, you can inspect the merged settings, compiled providers, and the detected base reference:
+After configuring, you can inspect the merged settings, compiled providers, and the detected base reference. Pass `--path`
+if the repository lives elsewhere:
 ```bash
-reviewlens print-config
+reviewlens print-config --path .
 ```
 Look for the `Base ref:` line in the output to see which upstream branch will be used for diffs.
 


### PR DESCRIPTION
## Summary
- allow `print-config` to target a specified repository via `--path`
- pass `-C <path>` to `git rev-parse` when resolving the base reference
- document the new flag in quickstart guide

## Testing
- `cargo fmt --all`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c6684e84e8832db6816d0980f4b716