### PR TITLE
feat: expand default redaction patterns

### DIFF
--- a/crates/engine/src/config.rs
+++ b/crates/engine/src/config.rs
@@ -147,7 +147,11 @@ impl Default for RedactionConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            patterns: Vec::new(),
+            patterns: vec![
+                "(?i)api[_-]?key".to_string(),
+                "aws_secret_access_key".to_string(),
+                "token".to_string(),
+            ],
         }
     }
 }

--- a/crates/engine/tests/config.rs
+++ b/crates/engine/tests/config.rs
@@ -49,6 +49,14 @@ fn default_config_is_sane() {
     let config = Config::default();
     assert_eq!(config.llm.provider, Provider::Null);
     assert!(config.privacy.redaction.enabled); // Should be true by default
+    assert_eq!(
+        config.privacy.redaction.patterns,
+        vec![
+            "(?i)api[_-]?key".to_string(),
+            "aws_secret_access_key".to_string(),
+            "token".to_string(),
+        ]
+    );
     assert!(config.rules.secrets.enabled);
     assert_eq!(config.rules.secrets.severity, Severity::Medium);
 }

--- a/crates/engine/tests/redaction.rs
+++ b/crates/engine/tests/redaction.rs
@@ -5,9 +5,17 @@ use engine::redact_text;
 fn redacts_configured_patterns() {
     let mut config = Config::default();
     config.privacy.redaction.patterns.push("secret".to_string());
-    let input = "this has a secret token";
+    let input = "this has a secret value";
     let output = redact_text(&config, input);
-    assert_eq!(output, "this has a [REDACTED] token");
+    assert_eq!(output, "this has a [REDACTED] value");
+}
+
+#[test]
+fn redacts_default_patterns() {
+    let config = Config::default();
+    let input = "API-KEY aws_secret_access_key token";
+    let output = redact_text(&config, input);
+    assert_eq!(output, "[REDACTED] [REDACTED] [REDACTED]");
 }
 
 #[test]

--- a/docs/config.md
+++ b/docs/config.md
@@ -38,14 +38,14 @@ Set `provider` and `api_key` to use a remote model. The default `provider = "nul
 ```toml
 [privacy.redaction]
 enabled = true
-patterns = ["aws_secret", "api_key", "token="]
+patterns = ["(?i)api[_-]?key", "aws_secret_access_key", "token"]
 ```
-Secret redaction is enabled by default and ships with patterns for AWS secrets, API keys, and token parameters.
+Secret redaction is enabled by default and ships with patterns for API keys, AWS secret access keys, and generic tokens.
 Extend the list by appending additional regular expressions:
 
 ```toml
 [privacy.redaction]
-patterns = ["aws_secret", "api_key", "token=", "passphrase"]
+patterns = ["(?i)api[_-]?key", "aws_secret_access_key", "token", "passphrase"]
 ```
 
 Override the defaults entirely with the `REVIEWLENS_PRIVACY_REDACTION_PATTERNS` environment variable or the

--- a/reviewlens.toml.example
+++ b/reviewlens.toml.example
@@ -53,7 +53,7 @@ temperature = 0.0  # default for deterministic output
 # Enable redaction of sensitive content from prompts and logs.
 enabled = true
 # Regular expression patterns to redact.
-patterns = ["aws_secret", "api_key", "token="]
+patterns = ["(?i)api[_-]?key", "aws_secret_access_key", "token"]
 
 
 # --- Report Settings ---


### PR DESCRIPTION
## Summary
- expand default redaction patterns to cover API keys, AWS secret access keys, and generic tokens
- document the new default patterns in `docs/config.md`
- adjust tests to reflect and verify the updated defaults

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c6684decc4832d9394643a490ada8f