### PR TITLE
Fix Go server XSS scanner to flag FormValue writes

### DIFF
--- a/crates/engine/src/scanner/server_xss_go.rs
+++ b/crates/engine/src/scanner/server_xss_go.rs
@@ -7,9 +7,8 @@ use regex::Regex;
 pub struct ServerXssGoScanner;
 
 static TEXT_TEMPLATE_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?i)text/template").unwrap());
-static UNSAFE_WRITE_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"(?i)fmt\.Fprintf\s*\(\s*w,[^)]*\+"#).unwrap()
-});
+static UNSAFE_WRITE_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r#"(?i)fmt\.Fprintf\s*\(\s*w,[^)]*\+"#).unwrap());
 
 impl Scanner for ServerXssGoScanner {
     fn name(&self) -> &'static str {
@@ -36,7 +35,9 @@ impl Scanner for ServerXssGoScanner {
                     )),
                 });
             }
-            if UNSAFE_WRITE_REGEX.is_match(line) {
+            if UNSAFE_WRITE_REGEX.is_match(line)
+                || (line.contains("w.Write(") && line.contains("FormValue("))
+            {
                 issues.push(Issue {
                     title: "Unescaped user input written to ResponseWriter".to_string(),
                     description:


### PR DESCRIPTION
## Summary
- flag unescaped `w.Write` with `FormValue` in Go code

## Testing
- `cargo test -p engine --test server_xss_go`
- `cargo test -p engine`


------
https://chatgpt.com/codex/tasks/task_e_68c67627b92c832d86aa883f4407c01d