### PR TITLE
Raise default fail-on severity to high

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ reviewlens check --base-ref main
 ```
 
 By default, the command exits with a non-zero status if any issue of
-severity `low` or higher is found. Use `--fail-on <severity>` or set
-`fail-on` in `reviewlens.toml` to raise this threshold.
+severity `high` or higher is found. Use `--fail-on <severity>` or set
+`fail-on` in `reviewlens.toml` to adjust this threshold.
 
 The review report will be saved to `review_report.md` by default. You can view it with:
 ```bash

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -28,7 +28,7 @@ pub struct CheckArgs {
     pub output: String,
 
     /// Minimum issue severity that will trigger a non-zero exit.
-    /// Defaults to the `fail-on` setting in `reviewlens.toml` (`low` if unset).
+    /// Defaults to the `fail-on` setting in `reviewlens.toml` (`high` if unset).
     #[arg(long, value_enum)]
     pub fail_on: Option<Severity>,
 }

--- a/crates/cli/tests/smoke.rs
+++ b/crates/cli/tests/smoke.rs
@@ -93,6 +93,8 @@ fn check_command_respects_path_argument() {
         repo_str,
         "--base-ref",
         "HEAD",
+        "--fail-on",
+        "low",
         "--output",
         output_str,
     ]);
@@ -140,7 +142,15 @@ fn check_command_reports_issues_and_exit_code() {
     fs::write(repo.join("file.txt"), "api_key = \"ABCDEFGHIJKLMNOP\"\n").unwrap();
 
     let mut cmd = Command::cargo_bin("reviewlens").unwrap();
-    cmd.args(["check", "--path", repo_str, "--base-ref", "HEAD"]);
+    cmd.args([
+        "check",
+        "--path",
+        repo_str,
+        "--base-ref",
+        "HEAD",
+        "--fail-on",
+        "low",
+    ]);
 
     cmd.assert().code(1);
 }
@@ -298,6 +308,8 @@ fn check_command_redacts_secrets_in_report() {
         repo_str,
         "--base-ref",
         "HEAD",
+        "--fail-on",
+        "low",
         "--output",
         output_str,
     ]);

--- a/crates/engine/src/config.rs
+++ b/crates/engine/src/config.rs
@@ -335,5 +335,5 @@ impl Default for Config {
 }
 
 fn default_fail_on() -> Severity {
-    Severity::Low
+    Severity::High
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -5,6 +5,10 @@
 2. Environment variables (prefixed with `REVIEWLENS_`)
 3. Settings in `reviewlens.toml`
 
+## Fail level
+
+The `fail-on` setting specifies the minimum issue severity that will cause a non-zero exit code. If omitted, it defaults to `high`.
+
 ## Paths
 Define which files are scanned:
 ```toml

--- a/reviewlens.toml.example
+++ b/reviewlens.toml.example
@@ -10,8 +10,8 @@
 path = ".reviewlens/index/index.json"
 
 # Minimum issue severity that triggers a non-zero exit code.
-# Defaults to "low" if omitted.
-fail-on = "low"
+# Defaults to "high" if omitted.
+# fail-on = "high"
 
 [paths]
 # Paths to include (allow) in the analysis. Globs are supported.


### PR DESCRIPTION
## Summary
- default to high severity when determining fail-on threshold
- reflect new fail level in example config and documentation
- adjust smoke tests and README for updated fail behavior

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c69d19db00832da4f915029eb54133