### PR TITLE
feat(cli): add optional progress indicator

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,6 +21,7 @@ anyhow.workspace = true
 # CLI-specific dependencies
 clap = { version = "4.5", features = ["derive", "env"] }
 serde_json = "1.0"
+indicatif = "0.17"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -9,8 +9,10 @@ use engine::ReviewEngine;
 use std::env;
 use std::fs;
 use std::process::Command;
+use std::time::Duration;
 
 use anyhow::Context;
+use indicatif::{ProgressBar, ProgressStyle};
 
 #[derive(Args, Debug)]
 pub struct CheckArgs {
@@ -31,6 +33,14 @@ pub struct CheckArgs {
     /// Defaults to the `fail-on` setting in `reviewlens.toml` (`low` if unset).
     #[arg(long, value_enum)]
     pub fail_on: Option<Severity>,
+
+    /// Suppress the progress bar output.
+    #[arg(long, default_value_t = false)]
+    pub no_progress: bool,
+
+    /// Emit condensed output suitable for CI environments.
+    #[arg(long, default_value_t = false)]
+    pub ci: bool,
 }
 
 /// Executes the `check` subcommand.
@@ -109,10 +119,23 @@ async fn execute(args: CheckArgs, engine: &ReviewEngine) -> anyhow::Result<bool>
 
     // 2. Call the engine to run the review and capture its report.
     // Ensure file reads are relative to the provided path.
+    let progress = if !args.no_progress && !args.ci {
+        let pb = ProgressBar::new_spinner();
+        pb.set_style(ProgressStyle::with_template("{spinner} {msg}").expect("spinner template"));
+        pb.enable_steady_tick(Duration::from_millis(100));
+        pb.set_message("Reviewing diff...");
+        Some(pb)
+    } else {
+        None
+    };
+
     let report = {
         let original_dir = env::current_dir().with_context(|| "failed to get current directory")?;
         env::set_current_dir(&args.path)
             .with_context(|| format!("failed to change to directory {}", args.path))?;
+        if let Some(pb) = &progress {
+            pb.set_message("Running review engine...");
+        }
         let result = engine
             .run(&diff_content)
             .await
@@ -122,14 +145,22 @@ async fn execute(args: CheckArgs, engine: &ReviewEngine) -> anyhow::Result<bool>
         result?
     };
 
+    if let Some(pb) = progress {
+        pb.finish_and_clear();
+    }
+
     // Print the summary and hotspots to stdout for quick visibility.
-    println!("Summary: {}", report.summary);
-    if report.hotspots.is_empty() {
-        println!("No hotspots identified.");
+    if args.ci {
+        println!("{}", report.summary);
     } else {
-        println!("Top hotspots:");
-        for spot in &report.hotspots {
-            println!("- {}", spot);
+        println!("Summary: {}", report.summary);
+        if report.hotspots.is_empty() {
+            println!("No hotspots identified.");
+        } else {
+            println!("Top hotspots:");
+            for spot in &report.hotspots {
+                println!("- {}", spot);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- add `indicatif` progress spinner to `check` command
- allow disabling spinner via `--no-progress` or implicit in `--ci`
- condense CLI output in CI mode

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c69ed86324832da39c130e46da8ace