### PR TITLE
Restrict CI workflow to main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
-  push:
   pull_request:
+    branches: [main]
+  push:
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary
- limit CI workflow triggers to main branch for push and pull_request events

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c6a325d864832d9f14293478ef2c8d