### PR TITLE
feat(cli): support auto diff detection

### DIFF
--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -11,13 +11,32 @@ use std::fs;
 use std::process::Command;
 
 use anyhow::Context;
+use std::str::FromStr;
+
+#[derive(Debug, Clone)]
+pub enum DiffTarget {
+    Auto,
+    Ref(String),
+}
+
+impl FromStr for DiffTarget {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.eq_ignore_ascii_case("auto") {
+            Ok(DiffTarget::Auto)
+        } else {
+            Ok(DiffTarget::Ref(s.to_string()))
+        }
+    }
+}
 
 #[derive(Args, Debug)]
 pub struct CheckArgs {
-    /// The base reference to compare against for generating a diff.
-    /// If not provided, the upstream of the current branch is used.
-    #[arg(long, alias = "diff")]
-    pub base_ref: Option<String>,
+    /// The diff reference to compare against for generating a diff.
+    /// Use `auto` to detect the upstream of the current branch.
+    #[arg(long, alias = "base-ref", default_value = "auto")]
+    pub diff: DiffTarget,
 
     /// The path to the repository to check.
     #[arg(long, default_value = ".")]
@@ -69,30 +88,33 @@ async fn execute(args: CheckArgs, engine: &ReviewEngine) -> anyhow::Result<bool>
     log::info!("  Path: {}", args.path);
     log::info!("  Output: {}", args.output);
 
-    // Resolve the base reference, falling back to upstream if not provided.
-    let base_ref = if let Some(base) = args.base_ref.clone() {
-        base
-    } else {
-        let upstream_output = Command::new("git")
-            .args([
-                "-C",
-                &args.path,
-                "rev-parse",
-                "--abbrev-ref",
-                "--symbolic-full-name",
-                "@{u}",
-            ])
-            .output()
-            .map_err(|e| EngineError::Config(format!("failed to detect upstream base: {}", e)))?;
-        if !upstream_output.status.success() {
-            return Err(
-                EngineError::Config("failed to detect upstream base reference".into()).into(),
-            );
+    // Resolve the diff target, falling back to upstream if set to auto.
+    let base_ref = match &args.diff {
+        DiffTarget::Ref(base) => base.clone(),
+        DiffTarget::Auto => {
+            let upstream_output = Command::new("git")
+                .args([
+                    "-C",
+                    &args.path,
+                    "rev-parse",
+                    "--abbrev-ref",
+                    "--symbolic-full-name",
+                    "@{u}",
+                ])
+                .output()
+                .map_err(|e| {
+                    EngineError::Config(format!("failed to detect upstream base: {}", e))
+                })?;
+            if !upstream_output.status.success() {
+                return Err(
+                    EngineError::Config("failed to detect upstream base reference".into()).into(),
+                );
+            }
+            String::from_utf8(upstream_output.stdout)
+                .context("upstream output was not valid UTF-8")?
+                .trim()
+                .to_string()
         }
-        String::from_utf8(upstream_output.stdout)
-            .context("upstream output was not valid UTF-8")?
-            .trim()
-            .to_string()
     };
     log::info!("  Base ref: {}", base_ref);
 

--- a/crates/cli/tests/smoke.rs
+++ b/crates/cli/tests/smoke.rs
@@ -88,13 +88,7 @@ fn check_command_respects_path_argument() {
 
     let mut cmd = Command::cargo_bin("reviewlens").unwrap();
     cmd.args([
-        "check",
-        "--path",
-        repo_str,
-        "--base-ref",
-        "HEAD",
-        "--output",
-        output_str,
+        "check", "--path", repo_str, "--diff", "HEAD", "--output", output_str,
     ]);
 
     let output = cmd.output().expect("failed to execute command");
@@ -140,7 +134,7 @@ fn check_command_reports_issues_and_exit_code() {
     fs::write(repo.join("file.txt"), "api_key = \"ABCDEFGHIJKLMNOP\"\n").unwrap();
 
     let mut cmd = Command::cargo_bin("reviewlens").unwrap();
-    cmd.args(["check", "--path", repo_str, "--base-ref", "HEAD"]);
+    cmd.args(["check", "--path", repo_str, "--diff", "HEAD"]);
 
     cmd.assert().code(1);
 }
@@ -187,20 +181,14 @@ fn check_command_respects_fail_on_from_config() {
 
     let mut cmd = Command::cargo_bin("reviewlens").unwrap();
     cmd.args([
-        "--config",
-        config_str,
-        "check",
-        "--path",
-        repo_str,
-        "--base-ref",
-        "HEAD",
+        "--config", config_str, "check", "--path", repo_str, "--diff", "HEAD",
     ]);
 
     cmd.assert().code(0);
 }
 
 #[test]
-fn check_command_without_upstream_or_base_ref_errors() {
+fn check_command_without_upstream_or_diff_errors() {
     let temp = tempdir().unwrap();
     let repo = temp.path();
     let repo_str = repo.to_str().unwrap();
@@ -291,14 +279,7 @@ fn check_command_redacts_secrets_in_report() {
 
     let mut cmd = Command::cargo_bin("reviewlens").unwrap();
     cmd.args([
-        "--config",
-        config_str,
-        "check",
-        "--path",
-        repo_str,
-        "--base-ref",
-        "HEAD",
-        "--output",
+        "--config", config_str, "check", "--path", repo_str, "--diff", "HEAD", "--output",
         output_str,
     ]);
 


### PR DESCRIPTION
## Summary
- support `--diff` flag using `Auto` or `Ref` to determine base reference
- default to upstream detection when `--diff auto`
- update smoke tests to use new flag

## Testing
- `cargo fmt --all`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c69ed77a38832d98735570d89825d6