### PR TITLE
feat: add JSON report option

### DIFF
--- a/crates/cli/tests/smoke.rs
+++ b/crates/cli/tests/smoke.rs
@@ -1,6 +1,7 @@
 use assert_cmd::Command;
 use serde_json::Value;
 use std::fs;
+use std::path::Path;
 use std::process::Command as StdCommand;
 use tempfile::tempdir;
 
@@ -305,6 +306,77 @@ fn check_command_redacts_secrets_in_report() {
     let output = cmd.output().expect("failed to execute command");
     assert_eq!(output.status.code(), Some(1));
     let report = fs::read_to_string(output_path).unwrap();
+    assert!(report.contains("[REDACTED]"));
+    assert!(!report.contains("api_key"));
+    assert!(!report.contains("ABCDEFGHIJKLMNOPQRSTUVWX"));
+}
+
+#[test]
+fn check_command_generates_json_report_and_redacts_secrets() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path();
+    let repo_str = repo.to_str().unwrap();
+
+    // Initialize git repository
+    StdCommand::new("git")
+        .args(["init", repo_str])
+        .output()
+        .expect("git init failed");
+    StdCommand::new("git")
+        .args(["-C", repo_str, "config", "user.email", "you@example.com"])
+        .output()
+        .expect("git config email failed");
+    StdCommand::new("git")
+        .args(["-C", repo_str, "config", "user.name", "Your Name"])
+        .output()
+        .expect("git config name failed");
+
+    // Create initial commit
+    fs::write(repo.join("file.txt"), "hello\n").unwrap();
+    StdCommand::new("git")
+        .args(["-C", repo_str, "add", "."])
+        .output()
+        .expect("git add failed");
+    StdCommand::new("git")
+        .args(["-C", repo_str, "commit", "-m", "init"])
+        .output()
+        .expect("git commit failed");
+
+    // Modify file to introduce a secret
+    fs::write(
+        repo.join("file.txt"),
+        "api_key = \"ABCDEFGHIJKLMNOPQRSTUVWX\"\n",
+    )
+    .unwrap();
+
+    // Configure redaction pattern to remove the secret value and key
+    fs::write(
+        repo.join("reviewlens.toml"),
+        "[privacy.redaction]\nenabled = true\npatterns = [\"api_key\", \"ABCDEFGHIJKLMNOPQRSTUVWX\"]\n",
+    )
+    .unwrap();
+    let config_path = repo.join("reviewlens.toml");
+    let config_str = config_path.to_str().unwrap();
+
+    let mut cmd = Command::cargo_bin("reviewlens").unwrap();
+    cmd.args([
+        "--config",
+        config_str,
+        "check",
+        "--path",
+        repo_str,
+        "--base-ref",
+        "HEAD",
+        "--format",
+        "json",
+    ]);
+
+    let output = cmd.output().expect("failed to execute command");
+    assert_eq!(output.status.code(), Some(1));
+
+    let report_path = Path::new("review_report.json");
+    assert!(report_path.exists());
+    let report = fs::read_to_string(report_path).unwrap();
     assert!(report.contains("[REDACTED]"));
     assert!(!report.contains("api_key"));
     assert!(!report.contains("ABCDEFGHIJKLMNOPQRSTUVWX"));

--- a/crates/engine/src/report/mod.rs
+++ b/crates/engine/src/report/mod.rs
@@ -31,6 +31,7 @@ pub struct RuntimeMetadata {
 }
 
 /// Represents the final, consolidated review findings.
+#[derive(Serialize)]
 pub struct ReviewReport {
     pub summary: String,
     pub issues: Vec<Issue>,
@@ -61,6 +62,9 @@ pub trait ReportGenerator {
 
 /// A generator for creating Markdown-formatted reports.
 pub struct MarkdownGenerator;
+
+/// A generator for creating JSON-formatted reports.
+pub struct JsonGenerator;
 
 impl ReportGenerator for MarkdownGenerator {
     fn generate(&self, report: &ReviewReport) -> Result<String> {
@@ -162,5 +166,12 @@ impl ReportGenerator for MarkdownGenerator {
         md.push_str("\n```\n");
 
         Ok(md)
+    }
+}
+
+impl ReportGenerator for JsonGenerator {
+    fn generate(&self, report: &ReviewReport) -> Result<String> {
+        serde_json::to_string_pretty(report)
+            .map_err(|e| crate::error::EngineError::Report(e.to_string()))
     }
 }

--- a/crates/engine/src/scanner/mod.rs
+++ b/crates/engine/src/scanner/mod.rs
@@ -9,11 +9,12 @@ use crate::{
 };
 use once_cell::sync::Lazy;
 use regex::Regex;
+use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::{Mutex, Once};
 
 /// Represents an issue found by a scanner.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Issue {
     pub title: String,
     pub description: String,


### PR DESCRIPTION
## Summary
- support generating JSON reports alongside Markdown
- allow `reviewlens check` to choose output format and default filename
- cover JSON redaction path with tests
- remove duplicate `JsonGenerator` definition to fix build

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c69edbf790832da4b5b83215d223a9