### PR TITLE
Template Homebrew formula for release automation

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,16 @@
+# Release checklist
+
+1. Build and upload release artifacts for all supported targets.
+2. Ensure each artifact includes a corresponding `.sha256` file.
+3. Update the Homebrew formula by running:
+   ```bash
+   python scripts/update-homebrew-formula.py <version>
+   ```
+   This script pulls checksums from the release artifacts and updates `homebrew-tap/reviewlens.rb`.
+4. Validate the formula on macOS and Linux:
+   ```bash
+   brew install --build-from-source homebrew-tap/reviewlens.rb
+   reviewlens --version
+   ```
+   Run the command on both macOS and Linux and confirm the reported version matches the release tag.
+5. Commit the updated formula and proceed with tagging the release.

--- a/homebrew-tap/reviewlens.rb
+++ b/homebrew-tap/reviewlens.rb
@@ -1,25 +1,27 @@
 class ReviewLens < Formula
   desc "CLI for the Intelligent Code Review Agent"
   homepage "https://github.com/Review-LensAi/reviewlens"
-  version "1.0.0"
+  version "<VERSION>"
 
+  # The sha256 placeholders below are updated by
+  # scripts/update-homebrew-formula.py during release.
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/Review-LensAi/reviewlens/releases/download/v\#{version}/reviewlens-aarch64-apple-darwin.tar.gz"
-      sha256 "984c1d422681008b4a7d7ba7a05519cf6542b29d77b5c009836c186838d710db"
+      sha256 "<ARM64_MAC_SHA256>"
     else
       url "https://github.com/Review-LensAi/reviewlens/releases/download/v\#{version}/reviewlens-x86_64-apple-darwin.tar.gz"
-      sha256 "4272c939af27ec09cd87cbe78cedded84fc133f84bd656e3fe2827ce99933bfc"
+      sha256 "<X86_64_MAC_SHA256>"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "https://github.com/Review-LensAi/reviewlens/releases/download/v\#{version}/reviewlens-aarch64-unknown-linux-gnu.tar.gz"
-      sha256 "c845d5bcfeb8e45afeb3ffeb061dcdebff296ba9f73b3d0661726afc49afc41f"
+      sha256 "<ARM64_LINUX_SHA256>"
     else
       url "https://github.com/Review-LensAi/reviewlens/releases/download/v\#{version}/reviewlens-x86_64-unknown-linux-gnu.tar.gz"
-      sha256 "ae17f91b06e660145133de6ba806e2c8194835bc8bfb9e0030adcae57870d115"
+      sha256 "<X86_64_LINUX_SHA256>"
     end
   end
 

--- a/scripts/update-homebrew-formula.py
+++ b/scripts/update-homebrew-formula.py
@@ -26,7 +26,7 @@ for key, target in targets.items():
         checksums[key] = resp.read().decode().split()[0]
 
 content = formula.read_text()
-content = content.replace('version "1.0.0"', f'version "{version}"')
+content = content.replace('version "<VERSION>"', f'version "{version}"')
 for key, checksum in checksums.items():
     content = content.replace(f"<{key}>", checksum)
 formula.write_text(content)


### PR DESCRIPTION
## Summary
- Replace hardcoded checksums in Homebrew formula with placeholders updated from release artifacts.
- Adjust update-homebrew-formula.py to populate version and checksum placeholders.
- Add release checklist describing checksum update and brew install validation steps.

## Testing
- `python scripts/update-homebrew-formula.py 1.0.0` (HTTPError 404: Not Found)
- `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
- `brew install --build-from-source homebrew-tap/reviewlens.rb` (formula must be in a tap)
- `cargo test` (compilation errors)


------
https://chatgpt.com/codex/tasks/task_e_68c6c8c50be8832db8928d4a73aaa85b