### PR TITLE
feat(cli): analyze changed files by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ Run a review from the root of your project:
 # Run a review against the 'main' branch
 reviewlens check --base-ref main
 ```
+By default, only files changed relative to the base reference are analyzed. Use
+`--no-only-changed` to review the entire repository.
 
 By default, the command exits with a non-zero status if any issue of severity
 `high` or higher is found. Use `--fail-on <severity>` or set `fail-on` in

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -35,8 +35,9 @@ pub struct CheckArgs {
     #[arg(long, default_value_t = false)]
     pub ci: bool,
 
-    /// Analyze only files changed relative to the diff base.
-    #[arg(long)]
+    /// Analyze only files changed relative to the diff base. Use `--no-only-changed`
+    /// to analyze all files.
+    #[arg(long, default_value_t = true)]
     pub only_changed: bool,
 
     /// Disable progress output.

--- a/crates/cli/tests/only_changed_default.rs
+++ b/crates/cli/tests/only_changed_default.rs
@@ -1,0 +1,62 @@
+use assert_cmd::Command;
+use std::fs;
+use std::process::Command as StdCommand;
+use tempfile::tempdir;
+
+#[test]
+fn check_defaults_to_only_changed() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path();
+    let repo_str = repo.to_str().unwrap();
+
+    // Initialize git repository
+    StdCommand::new("git")
+        .args(["init", repo_str])
+        .output()
+        .expect("git init failed");
+    StdCommand::new("git")
+        .args(["-C", repo_str, "config", "user.email", "you@example.com"])
+        .output()
+        .expect("git config email failed");
+    StdCommand::new("git")
+        .args(["-C", repo_str, "config", "user.name", "Your Name"])
+        .output()
+        .expect("git config name failed");
+
+    // Create initial commit with a secret in one file and a normal file
+    fs::write(
+        repo.join("unchanged.txt"),
+        "api_key = \"ABCDEFGHIJKLMNOPQRSTUVWX\"\n",
+    )
+    .unwrap();
+    fs::write(repo.join("changed.txt"), "hello\n").unwrap();
+    StdCommand::new("git")
+        .args(["-C", repo_str, "add", "."])
+        .output()
+        .expect("git add failed");
+    StdCommand::new("git")
+        .args(["-C", repo_str, "commit", "-m", "init"])
+        .output()
+        .expect("git commit failed");
+
+    // Modify only one file after the commit
+    fs::write(repo.join("changed.txt"), "hello world\n").unwrap();
+
+    let mut cmd = Command::cargo_bin("reviewlens").unwrap();
+    let output = cmd
+        .args([
+            "check",
+            "--path",
+            repo_str,
+            "--base-ref",
+            "HEAD",
+            "--fail-on",
+            "low",
+        ])
+        .output()
+        .expect("failed to execute command");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Reviewed 1 file"));
+}

--- a/crates/cli/tests/smoke.rs
+++ b/crates/cli/tests/smoke.rs
@@ -1,7 +1,6 @@
 use assert_cmd::Command;
 use serde_json::Value;
 use std::fs;
-use std::path::Path;
 use std::process::Command as StdCommand;
 use tempfile::tempdir;
 
@@ -296,7 +295,8 @@ fn check_command_redacts_secrets_in_report() {
 
     let mut cmd = Command::cargo_bin("reviewlens").unwrap();
     cmd.args([
-        "--config", config_str, "check", "--path", repo_str, "--diff", "HEAD", "--output", output_str,
+        "--config", config_str, "check", "--path", repo_str, "--diff", "HEAD", "--output",
+        output_str,
     ]);
 
     let output = cmd.output().expect("failed to execute command");
@@ -354,6 +354,9 @@ fn check_command_generates_json_report_and_redacts_secrets() {
     let config_path = repo.join("reviewlens.toml");
     let config_str = config_path.to_str().unwrap();
 
+    let output_path = repo.join("review_report.json");
+    let output_str = output_path.to_str().unwrap();
+
     let mut cmd = Command::cargo_bin("reviewlens").unwrap();
     cmd.args([
         "--config",
@@ -372,9 +375,8 @@ fn check_command_generates_json_report_and_redacts_secrets() {
     let output = cmd.output().expect("failed to execute command");
     assert_eq!(output.status.code(), Some(1));
 
-    let report_path = Path::new("review_report.json");
-    assert!(report_path.exists());
-    let report = fs::read_to_string(report_path).unwrap();
+    assert!(output_path.exists());
+    let report = fs::read_to_string(output_path).unwrap();
     assert!(report.contains("[REDACTED]"));
     assert!(!report.contains("api_key"));
     assert!(!report.contains("ABCDEFGHIJKLMNOPQRSTUVWX"));

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -36,6 +36,8 @@ Then run the agent from the root of your project:
 ```bash
 reviewlens check --base-ref main
 ```
+By default, only files changed relative to the base reference are analyzed. Pass
+`--no-only-changed` to review the entire repository.
 The CLI prints a short summary and the top hotspots to stdout, while the full report is written to `review_report.md`.
 
 When three or more files reference one another, the report also includes a Mermaid sequence diagram visualizing the flow between them.


### PR DESCRIPTION
## Summary
- default `reviewlens check` to analyze only files changed relative to base ref
- document new behavior in README and quickstart
- add regression test for default diff behavior

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c6def7e990832db6ec68daa86ea925