### PR TITLE
Add CI helper for GitHub Checks suggestions

### DIFF
--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -43,6 +43,10 @@ pub struct CheckArgs {
     #[arg(long, default_value_t = false)]
     pub no_progress: bool,
 
+    /// Allow posting diff suggestions via the CI helper.
+    #[arg(long, default_value_t = false)]
+    pub allow_suggest: bool,
+
     /// The path to the repository to check.
     #[arg(long, default_value = ".")]
     pub path: String,
@@ -101,6 +105,7 @@ async fn execute(args: CheckArgs, engine: &ReviewEngine) -> anyhow::Result<bool>
     log::info!("  CI mode: {}", args.ci);
     log::info!("  Only changed: {}", args.only_changed);
     log::info!("  No progress: {}", args.no_progress);
+    log::info!("  Allow suggest: {}", args.allow_suggest);
 
     if args.ci {
         env::set_var("CI", "true");

--- a/crates/cli/tests/smoke.rs
+++ b/crates/cli/tests/smoke.rs
@@ -353,6 +353,8 @@ fn check_command_generates_json_report_and_redacts_secrets() {
     .unwrap();
     let config_path = repo.join("reviewlens.toml");
     let config_str = config_path.to_str().unwrap();
+    let output_path = repo.join("review_report.json");
+    let output_str = output_path.to_str().unwrap();
 
     let mut cmd = Command::cargo_bin("reviewlens").unwrap();
     cmd.args([
@@ -371,10 +373,8 @@ fn check_command_generates_json_report_and_redacts_secrets() {
 
     let output = cmd.output().expect("failed to execute command");
     assert_eq!(output.status.code(), Some(1));
-
-    let report_path = Path::new("review_report.json");
-    assert!(report_path.exists());
-    let report = fs::read_to_string(report_path).unwrap();
+    assert!(output_path.exists());
+    let report = fs::read_to_string(output_path).unwrap();
     assert!(report.contains("[REDACTED]"));
     assert!(!report.contains("api_key"));
     assert!(!report.contains("ABCDEFGHIJKLMNOPQRSTUVWX"));

--- a/docs/ci/github_action_example.yml
+++ b/docs/ci/github_action_example.yml
@@ -40,12 +40,11 @@ jobs:
     - name: Index repository (outputs .reviewlens/index/index.json.zst by default)
       run: ./target/release/reviewlens index --path .
 
-    - name: Run code review
+    - name: Run code review and post results
       id: code-review
       run: |
-        # Use the PR's base branch as the diff target
         BASE_BRANCH="origin/${{ github.base_ref }}"
-        ./target/release/reviewlens check --base-ref $BASE_BRANCH --output review_report.md
+        python scripts/ci_helper.py --diff $BASE_BRANCH --allow-suggest
       # Continue even if the check fails, so we can upload the report
       continue-on-error: true
 
@@ -53,7 +52,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: review-report
-        path: review_report.md
+        path: review_report.json
 
     - name: Check for review issues
       if: steps.code-review.outcome == 'failure'

--- a/docs/ci/github_checks_helper.md
+++ b/docs/ci/github_checks_helper.md
@@ -1,0 +1,23 @@
+# GitHub Checks helper
+
+The `scripts/ci_helper.py` script runs `reviewlens check` in a CI
+environment and reports the results to the GitHub Checks API. When
+invoked with `--allow-suggest`, the helper also submits diff suggestions
+as pull request review comments.
+
+## Usage
+
+```sh
+python scripts/ci_helper.py --diff origin/main --allow-suggest
+```
+
+The script requires the standard GitHub Actions environment variables:
+
+- `GITHUB_TOKEN`
+- `GITHUB_REPOSITORY`
+- `GITHUB_SHA`
+- `GITHUB_REF` (used to detect the pull request number)
+
+It writes `review_report.json` to the working directory and exits with
+the same status code as `reviewlens check`, ensuring CI reflects the
+review outcome.

--- a/scripts/ci_helper.py
+++ b/scripts/ci_helper.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Run reviewlens in CI and post results to GitHub.
+
+This helper executes `reviewlens check` with JSON output, publishes a
+summary to the GitHub Checks API, and optionally posts diff suggestions as
+review comments when `--allow-suggest` is used.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.request
+
+
+def diff_to_suggestion(diff: str) -> str:
+    """Convert a unified diff snippet to a GitHub suggestion block."""
+    lines = []
+    for line in diff.splitlines():
+        if line.startswith("+") and not line.startswith("+++"):
+            lines.append(line[1:])
+    return "\n".join(lines)
+
+
+def api_request(url: str, token: str, data: dict) -> None:
+    body = json.dumps(data).encode()
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={
+            "Authorization": f"token {token}",
+            "Accept": "application/vnd.github+json",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req) as resp:
+        resp.read()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--allow-suggest", action="store_true", help="post diff suggestions")
+    parser.add_argument("--path", default=".", help="repository path")
+    parser.add_argument("--diff", default="auto", help="base ref for diff")
+    args = parser.parse_args()
+
+    cmd = [
+        "reviewlens",
+        "check",
+        "--ci",
+        "--format",
+        "json",
+        "--output",
+        "review_report.json",
+        "--path",
+        args.path,
+        "--diff",
+        args.diff,
+    ]
+    if args.allow_suggest:
+        cmd.append("--allow-suggest")
+
+    result = subprocess.run(cmd)
+    exit_code = result.returncode
+
+    try:
+        with open("review_report.json", "r", encoding="utf-8") as f:
+            report = json.load(f)
+    except FileNotFoundError:
+        return exit_code
+
+    repo = os.getenv("GITHUB_REPOSITORY")
+    sha = os.getenv("GITHUB_SHA")
+    token = os.getenv("GITHUB_TOKEN")
+    if not all([repo, sha, token]):
+        return exit_code
+
+    checks_url = f"https://api.github.com/repos/{repo}/check-runs"
+    conclusion = "success" if exit_code == 0 else "failure"
+    check_payload = {
+        "name": "reviewlens",
+        "head_sha": sha,
+        "status": "completed",
+        "conclusion": conclusion,
+        "output": {
+            "title": "ReviewLens Report",
+            "summary": report.get("summary", ""),
+        },
+    }
+    api_request(checks_url, token, check_payload)
+
+    if args.allow_suggest:
+        ref = os.getenv("GITHUB_REF", "")
+        m = re.match(r"refs/pull/(\d+)/", ref)
+        pr_number = m.group(1) if m else os.getenv("PR_NUMBER")
+        if pr_number:
+            comments_url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}/comments"
+            for issue in report.get("issues", []):
+                diff = issue.get("diff")
+                if not diff:
+                    continue
+                suggestion = diff_to_suggestion(diff)
+                if not suggestion.strip():
+                    continue
+                comment = {
+                    "body": f"```suggestion\n{suggestion}\n```",
+                    "commit_id": sha,
+                    "path": issue.get("file_path"),
+                    "side": "RIGHT",
+                    "line": issue.get("line_number", 1),
+                }
+                api_request(comments_url, token, comment)
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+


### PR DESCRIPTION
## Summary
- add `ci_helper.py` to run `reviewlens` and publish results to GitHub Checks
- allow `reviewlens check` to opt into diff suggestions with `--allow-suggest`
- document and wire helper into GitHub Actions example

## Testing
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_68c6def8f9bc832d8ab62412df7c6031