### PR TITLE
Rely on default redaction patterns

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -42,10 +42,9 @@ Set `provider` and `api_key` to use a remote model. The default `provider = "nul
 ```toml
 [privacy.redaction]
 enabled = true
-patterns = ["(?i)api[_-]?key", "aws_secret_access_key", "token"]
+# patterns = ["(?i)api[_-]?key", "aws_secret_access_key", "token"]
 ```
-Secret redaction is enabled by default and ships with patterns for API keys, AWS secret access keys, and generic tokens.
-Extend the list by appending additional regular expressions:
+Secret redaction is enabled by default and ships with patterns for API keys, AWS secret access keys, and generic tokens. Omitting `patterns` keeps these built-in defaults. Extend the list by appending additional regular expressions:
 
 ```toml
 [privacy.redaction]

--- a/reviewlens.toml
+++ b/reviewlens.toml
@@ -47,7 +47,6 @@ temperature = 0
 # Enable redaction of sensitive content from prompts and logs.
 enabled = true
 # Regular expression patterns to redact.
-patterns = []
 
 
 # --- Rule and Scanner Configuration ---


### PR DESCRIPTION
## Summary
- Remove `patterns = []` from `reviewlens.toml` so built-in defaults apply
- Explain in docs that omitting `patterns` keeps API key/AWS/token redactions

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c792971980832da6064d08f2b2c2ef