### PR TITLE
chore: pin cargo-deny for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,8 @@ jobs:
 
       - name: Install cargo-audit and cargo-deny
         run: |
-          cargo install --locked cargo-audit cargo-deny
+          cargo install --locked cargo-audit
+          cargo install --locked cargo-deny --version 0.17.0
 
       - name: Build binary
         run: cargo build --release --bin reviewlens --target ${{ matrix.target }}


### PR DESCRIPTION
## Summary
- pin cargo-deny to version 0.17.0 in release workflow for rust 1.82

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c7e5d80d44832da863478633df7d3a