### PR TITLE
chore: install cross toolchain for arm64 release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,14 @@ jobs:
           cargo install --locked cargo-audit
           cargo install --locked cargo-deny --version 0.17.0
 
+      - name: Install cross toolchain
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross
+        env:
+          CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
+
       - name: Build binary
         run: cargo build --release --bin reviewlens --target ${{ matrix.target }}
 


### PR DESCRIPTION
## Summary
- install aarch64 cross compiler in release workflow

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c7ef3229e0832d84d14c186e84d4a2