### PR TITLE
Add cargo-deny license configuration

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,2 @@
+[licenses]
+allow = ["Apache-2.0", "MIT", "Unlicense", "0BSD", "Unicode-3.0", "BSD-3-Clause", "ISC", "MPL-2.0"]


### PR DESCRIPTION
## Summary
- add `deny.toml` configuring allowed licenses for `cargo-deny`

## Testing
- `cargo deny check licenses`


------
https://chatgpt.com/codex/tasks/task_e_68c7f5e88200832daa7ac915911f19e3