### PR TITLE
fix: use unique names for release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: release-asset
+          name: release-asset-${{ matrix.target }}
           path: ${{ steps.package.outputs.ARCHIVE_NAME }}
 
   release:
@@ -89,8 +89,9 @@ jobs:
       - name: Download all release assets
         uses: actions/download-artifact@v4
         with:
-          name: release-asset
+          pattern: release-asset-*
           path: release-assets
+          merge-multiple: true
 
       - name: List downloaded files
         run: ls -R release-assets


### PR DESCRIPTION
## Summary
- include matrix target in uploaded artifact names
- fetch all release artifacts using a pattern and merge into one directory

## Testing
- `cargo fmt`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c7fe7a73f8832da70067c35f6eff8d