### PR TITLE
Fix aarch64 build by specifying cross linker

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"


### PR DESCRIPTION
## Summary
- configure aarch64-unknown-linux-gnu linker to use `aarch64-linux-gnu-gcc`

## Testing
- `cargo test`
- `cargo build --release --target aarch64-unknown-linux-gnu`


------
https://chatgpt.com/codex/tasks/task_e_68c8133b6abc832dae360503d9a91bf0