### PR TITLE
Fix release workflow permissions for GHCR push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
       id-token: write
     env:
       COSIGN_EXPERIMENTAL: "true"


### PR DESCRIPTION
## Summary
- grant the release job permission to write packages so GHCR image pushes succeed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c8c93915d8832d9227724025693772