### PR TITLE
chore: improve homebrew formula updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,15 +140,62 @@ jobs:
           SHA_LINUX_ARM64=$(cat release-assets/reviewlens-aarch64-unknown-linux-gnu.tar.gz.sha256)
           SHA_MAC_AMD64=$(cat release-assets/reviewlens-x86_64-apple-darwin.tar.gz.sha256)
           SHA_MAC_ARM64=$(cat release-assets/reviewlens-aarch64-apple-darwin.tar.gz.sha256)
-          sed -i "s/version \".*\"/version \"${VERSION#v}\"/" homebrew-tap/reviewlens.rb
-          sed -i "s/<X86_64_LINUX_SHA256>/${SHA_LINUX_AMD64}/" homebrew-tap/reviewlens.rb
-          sed -i "s/<ARM64_LINUX_SHA256>/${SHA_LINUX_ARM64}/" homebrew-tap/reviewlens.rb
-          sed -i "s/<X86_64_MAC_SHA256>/${SHA_MAC_AMD64}/" homebrew-tap/reviewlens.rb
-          sed -i "s/<ARM64_MAC_SHA256>/${SHA_MAC_ARM64}/" homebrew-tap/reviewlens.rb
-          if grep -E '<[A-Z0-9_]+_SHA256>' homebrew-tap/reviewlens.rb; then
-            echo "Error: placeholder SHA256 values remain" >&2
-            exit 1
-          fi
+          python - <<'PY'
+import os
+from pathlib import Path
+
+formula = Path("homebrew-tap/reviewlens.rb")
+version = os.environ["VERSION"].lstrip("v")
+
+targets = {
+    "aarch64-apple-darwin": os.environ["SHA_MAC_ARM64"],
+    "x86_64-apple-darwin": os.environ["SHA_MAC_AMD64"],
+    "aarch64-unknown-linux-gnu": os.environ["SHA_LINUX_ARM64"],
+    "x86_64-unknown-linux-gnu": os.environ["SHA_LINUX_AMD64"],
+}
+
+lines = formula.read_text().splitlines()
+updated_lines = []
+i = 0
+while i < len(lines):
+    line = lines[i]
+    stripped = line.strip()
+
+    if stripped.startswith("version "):
+        indent = line[: len(line) - len(stripped)]
+        updated_lines.append(f'{indent}version "{version}"')
+        i += 1
+        continue
+
+    if 'url "https://github.com/Review-LensAi/reviewlens/releases/download/v\\#{version}/reviewlens-' in line:
+        updated_lines.append(line)
+        i += 1
+        if i >= len(lines):
+            raise SystemExit("Expected sha256 line after url")
+        sha_line = lines[i]
+        sha_stripped = sha_line.strip()
+        if not sha_stripped.startswith("sha256 "):
+            raise SystemExit("Expected sha256 line after url")
+
+        replaced = False
+        for target, checksum in targets.items():
+            if f"reviewlens-{target}.tar.gz" in line:
+                indent = sha_line[: len(sha_line) - len(sha_stripped)]
+                updated_lines.append(f'{indent}sha256 "{checksum}"')
+                replaced = True
+                break
+
+        if not replaced:
+            raise SystemExit(f"No checksum provided for url: {line}")
+
+        i += 1
+        continue
+
+    updated_lines.append(line)
+    i += 1
+
+formula.write_text("\n".join(updated_lines) + "\n")
+PY
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add homebrew-tap/reviewlens.rb

--- a/homebrew-tap/reviewlens.rb
+++ b/homebrew-tap/reviewlens.rb
@@ -3,25 +3,25 @@ class ReviewLens < Formula
   homepage "https://github.com/Review-LensAi/reviewlens"
   version "1.0.1"
 
-  # The sha256 placeholders below are updated by
-  # scripts/update-homebrew-formula.py during release.
+  # Version and sha256 values are updated automatically by
+  # scripts/update-homebrew-formula.py during release preparation.
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/Review-LensAi/reviewlens/releases/download/v\#{version}/reviewlens-aarch64-apple-darwin.tar.gz"
-      sha256 "b5233e197933888d246ebaa700d0ff8142f83087c511b96dec2dc5c37dd4f281"
+      sha256 "d359db211ebbd7bc4f236d09dd8e8e784f4715fb1e5d3d734f75eaf5a82900dc"
     else
       url "https://github.com/Review-LensAi/reviewlens/releases/download/v\#{version}/reviewlens-x86_64-apple-darwin.tar.gz"
-      sha256 "dc8681b0e35a0fb8f6eca24faae7d5e209945afd8f79adc4e9a2b6f565a33804"
+      sha256 "329a861f79766574c8dc1f04906d69d9a2e924a0ac541ef8c179b066570771d6"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "https://github.com/Review-LensAi/reviewlens/releases/download/v\#{version}/reviewlens-aarch64-unknown-linux-gnu.tar.gz"
-      sha256 "cd0659f509d049a4d7195967b22fa6ea1b8b403e26e1a62d1d55fba2086907dd"
+      sha256 "137f9776a367c48c13cf33995700183a22ff2fe2ecd565bd5b29c55d56928522"
     else
       url "https://github.com/Review-LensAi/reviewlens/releases/download/v\#{version}/reviewlens-x86_64-unknown-linux-gnu.tar.gz"
-      sha256 "7ecc0d49d4112fe9afd6f6bf9b3095aab1925d502168ee415b80c35fd13a4d73"
+      sha256 "cb1d30a59b5ca47f70cd506fdff36c2e43598ac4f8c11e79c1ba7b18deb38cde"
     end
   end
 

--- a/scripts/update-homebrew-formula.py
+++ b/scripts/update-homebrew-formula.py
@@ -3,6 +3,7 @@ import sys
 import pathlib
 import subprocess
 import urllib.request
+from typing import Dict
 
 if len(sys.argv) != 2:
     print(f"Usage: {sys.argv[0]} <version>", file=sys.stderr)
@@ -12,24 +13,60 @@ version = sys.argv[1]
 repo = "Review-LensAi/reviewlens"
 formula = pathlib.Path(__file__).resolve().parent.parent / "homebrew-tap" / "reviewlens.rb"
 
-targets = {
-    "ARM64_MAC_SHA256": "aarch64-apple-darwin",
-    "X86_64_MAC_SHA256": "x86_64-apple-darwin",
-    "ARM64_LINUX_SHA256": "aarch64-unknown-linux-gnu",
-    "X86_64_LINUX_SHA256": "x86_64-unknown-linux-gnu",
-}
+targets = (
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-unknown-linux-gnu",
+)
 
-checksums = {}
-for key, target in targets.items():
+checksums: Dict[str, str] = {}
+for target in targets:
     url = f"https://github.com/{repo}/releases/download/v{version}/reviewlens-{target}.tar.gz.sha256"
     with urllib.request.urlopen(url) as resp:
-        checksums[key] = resp.read().decode().split()[0]
+        checksums[target] = resp.read().decode().split()[0]
 
-content = formula.read_text()
-content = content.replace('version "<VERSION>"', f'version "{version}"')
-for key, checksum in checksums.items():
-    content = content.replace(f"<{key}>", checksum)
-formula.write_text(content)
+lines = formula.read_text().splitlines()
+updated_lines = []
+i = 0
+while i < len(lines):
+    line = lines[i]
+    stripped = line.strip()
+
+    if stripped.startswith("version "):
+        indent = line[: len(line) - len(stripped)]
+        updated_lines.append(f'{indent}version "{version}"')
+        i += 1
+        continue
+
+    if 'url "https://github.com/Review-LensAi/reviewlens/releases/download/v\\#{version}/reviewlens-' in line:
+        updated_lines.append(line)
+        i += 1
+        if i >= len(lines):
+            raise SystemExit("Expected sha256 line after url")
+        sha_line = lines[i]
+        sha_stripped = sha_line.strip()
+        if not sha_stripped.startswith("sha256 "):
+            raise SystemExit("Expected sha256 line after url")
+
+        replaced = False
+        for target, checksum in checksums.items():
+            if f"reviewlens-{target}.tar.gz" in line:
+                indent = sha_line[: len(sha_line) - len(sha_stripped)]
+                updated_lines.append(f'{indent}sha256 "{checksum}"')
+                replaced = True
+                break
+
+        if not replaced:
+            raise SystemExit(f"No checksum found for url: {line}")
+
+        i += 1
+        continue
+
+    updated_lines.append(line)
+    i += 1
+
+formula.write_text("\n".join(updated_lines) + "\n")
 
 # verify installation if Homebrew is available
 if subprocess.call(["which", "brew"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) == 0:


### PR DESCRIPTION
## Summary
- rewrite the release workflow step that updates the Homebrew formula so it overwrites the existing version and sha256 entries using a Python helper instead of placeholder substitution
- teach scripts/update-homebrew-formula.py to locate each url stanza and replace the corresponding version and sha256 lines, keeping it usable after real digests are committed
- refresh the formula comment and recorded checksums to reflect the new automation flow

## Testing
- python3 scripts/update-homebrew-formula.py 1.0.0
- python3 scripts/update-homebrew-formula.py 1.0.1

------
https://chatgpt.com/codex/tasks/task_e_68cbf7168bc0832dbbdd79228a235985